### PR TITLE
Fix GitHub Action test failures and code formatting

### DIFF
--- a/internal/server/common_test.go
+++ b/internal/server/common_test.go
@@ -1,0 +1,19 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/ananthakumaran/paisa/internal/model"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// openTestDB opens an in-memory SQLite database and runs migrations for testing.
+func openTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	model.AutoMigrate(db)
+	return db
+}

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 
 	"github.com/ananthakumaran/paisa/internal/config"
-	"github.com/ananthakumaran/paisa/internal/model/session"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,29 +1,30 @@
 package utils
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestBuildSubPath(t *testing.T) {
-	path, err := BuildSubPath("/usr/home/john/paisa", "main.ledger")
+	path, err := BuildSubPath(filepath.FromSlash("/usr/home/john/paisa"), "main.ledger")
 	assert.Nil(t, err)
-	assert.Equal(t, "/usr/home/john/paisa/main.ledger", path)
+	assert.Equal(t, filepath.FromSlash("/usr/home/john/paisa/main.ledger"), path)
 
-	path, err = BuildSubPath("/usr/home/john/paisa", "subfolder/main.ledger")
+	path, err = BuildSubPath(filepath.FromSlash("/usr/home/john/paisa"), "subfolder/main.ledger")
 	assert.Nil(t, err)
-	assert.Equal(t, "/usr/home/john/paisa/subfolder/main.ledger", path)
+	assert.Equal(t, filepath.FromSlash("/usr/home/john/paisa/subfolder/main.ledger"), path)
 
-	path, err = BuildSubPath("/usr/home/john/paisa", "../../../subfolder/travel.ledger")
+	path, err = BuildSubPath(filepath.FromSlash("/usr/home/john/paisa"), "../../../subfolder/travel.ledger")
 	assert.Error(t, err)
 
-	path, err = BuildSubPath("/usr/home/john/paisa", "..")
+	path, err = BuildSubPath(filepath.FromSlash("/usr/home/john/paisa"), "..")
 	assert.Error(t, err)
 
-	path, err = BuildSubPath("/usr/home/john/paisa", "./..")
+	path, err = BuildSubPath(filepath.FromSlash("/usr/home/john/paisa"), "./..")
 	assert.Error(t, err)
 
-	path, err = BuildSubPath("/usr/home/john/paisa", "./../test.ledger")
+	path, err = BuildSubPath(filepath.FromSlash("/usr/home/john/paisa"), "./../test.ledger")
 	assert.Error(t, err)
 }


### PR DESCRIPTION
This pull request introduces improvements to testing utilities and cross-platform compatibility in path handling, as well as some cleanup of imports. The most significant changes are the addition of a helper for opening a test database, updates to path-related tests for portability, and minor import adjustments.

Testing utilities:

* Added a new `openTestDB` helper function in `internal/server/common_test.go` to simplify opening an in-memory SQLite database and running migrations for tests.

Cross-platform compatibility:

* Updated `TestBuildSubPath` in `internal/utils/utils_test.go` to use `filepath.FromSlash` for all path literals, ensuring tests work correctly across different operating systems.

Code cleanup:

* Removed an unused import of `session` from `internal/server/integration_test.go`.