### PR TITLE
Enhance commodity price sync with parallel fetching, throttling, and reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - **Year-over-Year "Until year" selector** — The Year-over-Year analysis page now includes an "Until year" dropdown alongside "Years to compare". Users can select an end year (e.g. 2025) so the comparison covers the N years up to and including that year (e.g. last 3 years until 2025 = 2023, 2024, 2025). Defaults to the current year, preserving existing behaviour. The `/api/expense` and `/api/income` endpoints now accept an optional `until_year` query parameter.
 
+- **Incremental price sync (delta updates)** — `SyncCommodities` now performs incremental syncs instead of fetching and replacing the full price history on every run.
+  - `PriceProvider.GetPrices` accepts a new `since time.Time` parameter. Providers use it to filter returned prices to those on or after the start-of-day of `since`; a zero value means fetch the full history (first run).
+  - `syncCommodities` reads the `last_price_sync` metadata timestamp and forwards it to every provider as `since`, enabling incremental fetches after the first sync.
+  - `UpsertAllByTypeNameAndID` now uses a pure UPSERT (INSERT … ON CONFLICT DO UPDATE) without first deleting existing rows. Historical prices are preserved across syncs; the same date's value is updated in place if the provider returns a corrected figure.
+  - New `price.FilterSince(prices, since)` helper: filters a `[]*Price` slice to entries on or after the start-of-day of `since` (UTC). Zero `since` returns the slice unmodified.
+
 #### Documentation
 
 - **Reference documentation updated** — All new features from this release cycle are now documented in the reference section:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 #### Features
 
+- **Epic 6: Account balance snapshots as-of date** — Assets balance and account detail flows now support historical as-of views for reconciliation.
+  - **Subtask 6.1 (Backend – Date filter on balance endpoints)** — Added `as_of_date` (`YYYY-MM-DD`) support to `GET /api/assets/balance`, `GET /api/gain/:account`, and new `GET /api/account/:account/balance`. Date defaults to today, rejects invalid format/future dates with `400 INVALID_REQUEST`, and excludes postings after the selected date.
+  - **Subtask 6.2 (Frontend – Date picker on balance pages)** — Added "View as of" date pickers on Assets → Balance and account detail pages; changing the date reloads balance data without page reload and displays the selected as-of date.
+  - **Subtask 6.3 (Frontend – Historical balance trend view)** — Added account-level "View Trend" with 6M/12M presets, custom start/end date filters, responsive SVG trend line, and current-balance marker.
+
 - **Granular progress reporting for sync jobs** — Users can now see per-commodity progress during long price sync operations instead of a static "Syncing…" spinner.
   - `Job` (worker package) gains `items_completed` and `total_items` integer fields, serialised as JSON and exposed via `GET /api/jobs/:id`.
   - `DetailedJobFn` now receives a thread-safe `progress func(completed, total int)` callback. `runDetailed` creates the callback and updates the job fields under the registry lock, eliminating any data race.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 #### Features
 
+- **Granular progress reporting for sync jobs** — Users can now see per-commodity progress during long price sync operations instead of a static "Syncing…" spinner.
+  - `Job` (worker package) gains `items_completed` and `total_items` integer fields, serialised as JSON and exposed via `GET /api/jobs/:id`.
+  - `DetailedJobFn` now receives a thread-safe `progress func(completed, total int)` callback. `runDetailed` creates the callback and updates the job fields under the registry lock, eliminating any data race.
+  - `syncCommodities` accepts a `progressFn func(completed, total int)` parameter and calls it after each commodity result is processed (the results loop is sequential, so the counter is exact).
+  - The navbar `SyncingIndicator` switches from "Syncing…" to an "X / Y" label while the price-scraper stage is active.
+  - The Sync History overlay shows a Bulma `<progress>` bar labelled "X of Y commodities" for any running job that has reported `total_items > 0`.
+  - The TypeScript `Job` interface in `utils.ts` mirrors the new `items_completed` and `total_items` fields. The `runningJob` derived store (in `src/lib/stores/jobs.ts`) exposes the active non-terminal job for consumption by `SyncingIndicator`.
+
 - **Year-over-Year "Until year" selector** — The Year-over-Year analysis page now includes an "Until year" dropdown alongside "Years to compare". Users can select an end year (e.g. 2025) so the comparison covers the N years up to and including that year (e.g. last 3 years until 2025 = 2023, 2024, 2025). Defaults to the current year, preserving existing behaviour. The `/api/expense` and `/api/income` endpoints now accept an optional `until_year` query parameter.
 
 - **Incremental price sync (delta updates)** — `SyncCommodities` now performs incremental syncs instead of fetching and replacing the full price history on every run.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 #### Performance
 
+- **Parallel commodity price fetching in sync** — `SyncCommodities` now fetches price histories using a bounded worker pool (5 concurrent fetches) with goroutines and `sync.WaitGroup`, reducing end-to-end sync time when many commodities are configured while avoiding unbounded provider request fan-out.
+
 - **Materialized account balance summary table** — Introduces `account_balances` table (migration v7) that stores pre-computed per-`(account, commodity)` balance totals updated atomically on every journal sync.
   - `account_balance.RefreshFromPostings(tx, postings)` — computes sums in-memory from the already-loaded postings slice and atomically replaces the entire `account_balances` table within the sync transaction. Forecast postings are excluded.
   - `account_balance.ByAccount(db, account)` — O(1) index lookup for a single account's balance rows, replacing the previous O(N) full `postings` table scan.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - **Incremental price sync (delta updates)** — `SyncCommodities` now performs incremental syncs instead of fetching and replacing the full price history on every run.
   - `PriceProvider.GetPrices` accepts a new `since time.Time` parameter. Providers use it to filter returned prices to those on or after the start-of-day of `since`; a zero value means fetch the full history (first run).
   - `syncCommodities` reads the `last_price_sync` metadata timestamp and forwards it to every provider as `since`, enabling incremental fetches after the first sync.
+  - The sync API now accepts `force_prices: true` to bypass `last_price_sync` and fetch the full commodity price history on demand. The Prices page exposes this via a new **Force Refresh** action.
   - `UpsertAllByTypeNameAndID` now uses a pure UPSERT (INSERT … ON CONFLICT DO UPDATE) without first deleting existing rows. Historical prices are preserved across syncs; the same date's value is updated in place if the provider returns a corrected figure.
   - New `price.FilterSince(prices, since)` helper: filters a `[]*Price` slice to entries on or after the start-of-day of `since` (UTC). Zero `since` returns the slice unmodified.
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -35,7 +35,7 @@ var updateCmd = &cobra.Command{
 		}
 
 		if syncAll || updateCommodities {
-			model.SyncCommodities(db)
+			model.SyncCommodities(db, nil)
 		}
 
 		if syncAll || updatePortfolios {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -35,7 +35,7 @@ var updateCmd = &cobra.Command{
 		}
 
 		if syncAll || updateCommodities {
-			model.SyncCommodities(db, nil)
+			model.SyncCommodities(db, false, nil)
 		}
 
 		if syncAll || updatePortfolios {

--- a/docs/reference/commodities.md
+++ b/docs/reference/commodities.md
@@ -303,6 +303,10 @@ the top right hand side corner or via `paisa update` command. Make
 sure to update the prices after you make any changes to your journal
 file or you want to fetch the latest value of the commodities.
 
+If you need to discard incremental sync state and rebuild the entire
+commodity price history, use the **Force Refresh** button on the
+**Ledger → Price** page. It triggers a full price sync from the UI.
+
 ## Price Export
 
 You can export your commodity price history from the **Ledger → Price**

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -159,12 +159,12 @@ type commodityPriceFetchResult struct {
 	err       error
 }
 
-func SyncCommodities(db *gorm.DB, progressFn func(completed, total int)) (SyncCommoditiesResult, error) {
+func SyncCommodities(db *gorm.DB, forcePrices bool, progressFn func(completed, total int)) (SyncCommoditiesResult, error) {
 	log.WithFields(log.Fields{"stage": "commodities"}).Info("Fetching commodities price history")
-	return syncCommodities(db, lo.Shuffle(commodity.All()), scraper.GetProviderByCode, commodityFetchWorkers, progressFn)
+	return syncCommodities(db, lo.Shuffle(commodity.All()), scraper.GetProviderByCode, commodityFetchWorkers, forcePrices, progressFn)
 }
 
-func syncCommodities(db *gorm.DB, commodities []config.Commodity, getProviderByCode func(string) price.PriceProvider, workers int, progressFn func(completed, total int)) (SyncCommoditiesResult, error) {
+func syncCommodities(db *gorm.DB, commodities []config.Commodity, getProviderByCode func(string) price.PriceProvider, workers int, forcePrices bool, progressFn func(completed, total int)) (SyncCommoditiesResult, error) {
 	if workers <= 0 {
 		workers = 1
 	}
@@ -175,18 +175,19 @@ func syncCommodities(db *gorm.DB, commodities []config.Commodity, getProviderByC
 	// Determine the since timestamp from the last successful price sync.
 	// A zero value means fetch the full history (first run or metadata missing).
 	var since time.Time
-	if lastSyncStr, err := metadata.GetOrDefault(db, LastPriceSyncKey, ""); err == nil && lastSyncStr != "" {
+	if forcePrices {
+		log.WithFields(log.Fields{"stage": "commodities"}).Info("Force refresh requested; fetching full price history")
+	} else if lastSyncStr, err := metadata.GetOrDefault(db, LastPriceSyncKey, ""); err == nil && lastSyncStr != "" {
 		if t, parseErr := time.Parse(time.RFC3339, lastSyncStr); parseErr == nil {
 			since = t
+			log.WithFields(log.Fields{"stage": "commodities", "since": since.Format(time.RFC3339)}).Info("Performing incremental price sync")
 		} else {
 			log.WithFields(log.Fields{"stage": "commodities", "value": lastSyncStr, "error": parseErr}).
 				Warn("Failed to parse last_price_sync metadata; falling back to full price history fetch")
+			log.WithFields(log.Fields{"stage": "commodities"}).Info("No previous price sync found; fetching full price history")
 		}
-	}
-	if since.IsZero() {
-		log.WithFields(log.Fields{"stage": "commodities"}).Info("No previous price sync found; fetching full price history")
 	} else {
-		log.WithFields(log.Fields{"stage": "commodities", "since": since.Format(time.RFC3339)}).Info("Performing incremental price sync")
+		log.WithFields(log.Fields{"stage": "commodities"}).Info("No previous price sync found; fetching full price history")
 	}
 
 	var result SyncCommoditiesResult

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -172,6 +172,23 @@ func syncCommodities(db *gorm.DB, commodities []config.Commodity, getProviderByC
 		workers = len(commodities)
 	}
 
+	// Determine the since timestamp from the last successful price sync.
+	// A zero value means fetch the full history (first run or metadata missing).
+	var since time.Time
+	if lastSyncStr, err := metadata.GetOrDefault(db, LastPriceSyncKey, ""); err == nil && lastSyncStr != "" {
+		if t, parseErr := time.Parse(time.RFC3339, lastSyncStr); parseErr == nil {
+			since = t
+		} else {
+			log.WithFields(log.Fields{"stage": "commodities", "value": lastSyncStr, "error": parseErr}).
+				Warn("Failed to parse last_price_sync metadata; falling back to full price history fetch")
+		}
+	}
+	if since.IsZero() {
+		log.WithFields(log.Fields{"stage": "commodities"}).Info("No previous price sync found; fetching full price history")
+	} else {
+		log.WithFields(log.Fields{"stage": "commodities", "since": since.Format(time.RFC3339)}).Info("Performing incremental price sync")
+	}
+
 	var result SyncCommoditiesResult
 	var errs []error
 	jobs := make(chan config.Commodity)
@@ -186,7 +203,7 @@ func syncCommodities(db *gorm.DB, commodities []config.Commodity, getProviderByC
 				name := commodity.Name
 				log.WithFields(log.Fields{"stage": "commodities", "commodity": name}).Info("Fetching commodity")
 				provider := getProviderByCode(commodity.Price.Provider)
-				prices, err := provider.GetPrices(commodity.Price.Code, name)
+				prices, err := provider.GetPrices(commodity.Price.Code, name, since)
 				results <- commodityPriceFetchResult{
 					commodity: commodity,
 					prices:    prices,

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -159,12 +159,12 @@ type commodityPriceFetchResult struct {
 	err       error
 }
 
-func SyncCommodities(db *gorm.DB) (SyncCommoditiesResult, error) {
+func SyncCommodities(db *gorm.DB, progressFn func(completed, total int)) (SyncCommoditiesResult, error) {
 	log.WithFields(log.Fields{"stage": "commodities"}).Info("Fetching commodities price history")
-	return syncCommodities(db, lo.Shuffle(commodity.All()), scraper.GetProviderByCode, commodityFetchWorkers)
+	return syncCommodities(db, lo.Shuffle(commodity.All()), scraper.GetProviderByCode, commodityFetchWorkers, progressFn)
 }
 
-func syncCommodities(db *gorm.DB, commodities []config.Commodity, getProviderByCode func(string) price.PriceProvider, workers int) (SyncCommoditiesResult, error) {
+func syncCommodities(db *gorm.DB, commodities []config.Commodity, getProviderByCode func(string) price.PriceProvider, workers int, progressFn func(completed, total int)) (SyncCommoditiesResult, error) {
 	if workers <= 0 {
 		workers = 1
 	}
@@ -223,7 +223,13 @@ func syncCommodities(db *gorm.DB, commodities []config.Commodity, getProviderByC
 		close(results)
 	}()
 
+	total := len(commodities)
+	itemsCompleted := 0
 	for fetched := range results {
+		itemsCompleted++
+		if progressFn != nil {
+			progressFn(itemsCompleted, total)
+		}
 		commodity := fetched.commodity
 		name := commodity.Name
 		prices := fetched.prices

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -3,6 +3,7 @@ package model
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ananthakumaran/paisa/internal/config"
@@ -150,21 +151,66 @@ type SyncCommoditiesResult struct {
 	Failures []string
 }
 
+const commodityFetchWorkers = 5
+
+type commodityPriceFetchResult struct {
+	commodity config.Commodity
+	prices    []*price.Price
+	err       error
+}
+
 func SyncCommodities(db *gorm.DB) (SyncCommoditiesResult, error) {
 	log.WithFields(log.Fields{"stage": "commodities"}).Info("Fetching commodities price history")
-	commodities := lo.Shuffle(commodity.All())
+	return syncCommodities(db, lo.Shuffle(commodity.All()), scraper.GetProviderByCode, commodityFetchWorkers)
+}
+
+func syncCommodities(db *gorm.DB, commodities []config.Commodity, getProviderByCode func(string) price.PriceProvider, workers int) (SyncCommoditiesResult, error) {
+	if workers <= 0 {
+		workers = 1
+	}
+	if workers > len(commodities) && len(commodities) > 0 {
+		workers = len(commodities)
+	}
 
 	var result SyncCommoditiesResult
 	var errs []error
-	for _, commodity := range commodities {
-		name := commodity.Name
-		log.WithFields(log.Fields{"stage": "commodities", "commodity": name}).Info("Fetching commodity")
-		code := commodity.Price.Code
-		var prices []*price.Price
-		var err error
+	jobs := make(chan config.Commodity)
+	results := make(chan commodityPriceFetchResult, len(commodities))
+	var wg sync.WaitGroup
 
-		provider := scraper.GetProviderByCode(commodity.Price.Provider)
-		prices, err = provider.GetPrices(code, name)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for commodity := range jobs {
+				name := commodity.Name
+				log.WithFields(log.Fields{"stage": "commodities", "commodity": name}).Info("Fetching commodity")
+				provider := getProviderByCode(commodity.Price.Provider)
+				prices, err := provider.GetPrices(commodity.Price.Code, name)
+				results <- commodityPriceFetchResult{
+					commodity: commodity,
+					prices:    prices,
+					err:       err,
+				}
+			}
+		}()
+	}
+
+	for _, commodity := range commodities {
+		jobs <- commodity
+	}
+	close(jobs)
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	for fetched := range results {
+		commodity := fetched.commodity
+		name := commodity.Name
+		prices := fetched.prices
+		err := fetched.err
 
 		if err != nil {
 			log.WithFields(log.Fields{"stage": "commodities", "commodity": name, "error": err}).Error("Failed to fetch commodity prices")
@@ -201,7 +247,7 @@ func SyncCommodities(db *gorm.DB) (SyncCommoditiesResult, error) {
 			}
 		}
 
-		if err := price.UpsertAllByTypeNameAndID(db, commodity.Type, name, code, prices); err != nil {
+		if err := price.UpsertAllByTypeNameAndID(db, commodity.Type, name, commodity.Price.Code, prices); err != nil {
 			log.WithFields(log.Fields{"stage": "commodities", "commodity": name, "error": err}).Error("Failed to save commodity prices")
 			msg := fmt.Sprintf("Failed to save price for %s: %s", name, err.Error())
 			errs = append(errs, fmt.Errorf("%s", msg))

--- a/internal/model/model_sync_commodities_test.go
+++ b/internal/model/model_sync_commodities_test.go
@@ -99,7 +99,7 @@ func TestSyncCommodities_UsesBoundedConcurrentFetching(t *testing.T) {
 
 	result, err := syncCommodities(db, commodities, func(string) price.PriceProvider {
 		return provider
-	}, 5)
+	}, 5, nil)
 	require.NoError(t, err)
 	assert.Empty(t, result.Failures)
 
@@ -165,7 +165,7 @@ func TestSyncCommodities_PassesSinceToProvider(t *testing.T) {
 	getProvider := func(_ string) price.PriceProvider { return stub }
 
 	// First call: no metadata → since must be zero (full history fetch).
-	_, err := syncCommodities(db, commodities, getProvider, 1)
+	_, err := syncCommodities(db, commodities, getProvider, 1, nil)
 	require.NoError(t, err)
 	assert.True(t, stub.receivedSince.IsZero(), "since must be zero when no last_price_sync metadata exists")
 
@@ -175,7 +175,7 @@ func TestSyncCommodities_PassesSinceToProvider(t *testing.T) {
 
 	// Second call: since must match the stored timestamp.
 	stub.receivedSince = time.Time{} // reset
-	_, err = syncCommodities(db, commodities, getProvider, 1)
+	_, err = syncCommodities(db, commodities, getProvider, 1, nil)
 	require.NoError(t, err)
 	assert.Equal(t, lastSync.UTC().Truncate(time.Second), stub.receivedSince.UTC().Truncate(time.Second),
 		"since must match the last_price_sync metadata value")
@@ -216,7 +216,7 @@ func TestSyncCommodities_IncrementalUpsertPreservesHistory(t *testing.T) {
 	}
 	getProvider := func(_ string) price.PriceProvider { return stub }
 
-	_, err := syncCommodities(db, commodities, getProvider, 1)
+	_, err := syncCommodities(db, commodities, getProvider, 1, nil)
 	require.NoError(t, err)
 
 	var count int64
@@ -235,9 +235,53 @@ func TestSyncCommodities_IncrementalUpsertPreservesHistory(t *testing.T) {
 			QuoteCommodity: "USD",
 		},
 	}
-	_, err = syncCommodities(db, commodities, getProvider, 1)
+	_, err = syncCommodities(db, commodities, getProvider, 1, nil)
 	require.NoError(t, err)
 
 	db.Model(&price.Price{}).Count(&count)
 	assert.Equal(t, int64(3), count, "incremental sync must add new prices without removing historical rows")
+}
+
+// TestSyncCommodities_ReportsProgress verifies that syncCommodities invokes
+// the progressFn callback once per commodity and that the final call reports
+// completed == total.
+func TestSyncCommodities_ReportsProgress(t *testing.T) {
+	db := openSyncCommoditiesTestDB(t)
+
+	stub := &sincePriceProvider{
+		prices: []*price.Price{
+			{
+				Date:           time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC),
+				CommodityType:  config.Stock,
+				CommodityID:    "X",
+				CommodityName:  "CommodityX",
+				Value:          decimal.NewFromInt(1),
+				QuoteCommodity: "USD",
+			},
+		},
+	}
+
+	commodities := []config.Commodity{
+		{Name: "CommodityX", Type: config.Stock, Price: config.Price{Provider: "since-stub", Code: "X"}},
+		{Name: "CommodityY", Type: config.Stock, Price: config.Price{Provider: "since-stub", Code: "Y"}},
+		{Name: "CommodityZ", Type: config.Stock, Price: config.Price{Provider: "since-stub", Code: "Z"}},
+	}
+	getProvider := func(_ string) price.PriceProvider { return stub }
+
+	var calls []struct{ completed, total int }
+	progressFn := func(completed, total int) {
+		calls = append(calls, struct{ completed, total int }{completed, total})
+	}
+
+	_, err := syncCommodities(db, commodities, getProvider, 1, progressFn)
+	require.NoError(t, err)
+
+	assert.Len(t, calls, len(commodities), "progressFn must be called once per commodity")
+	last := calls[len(calls)-1]
+	assert.Equal(t, len(commodities), last.completed, "final call must have completed == len(commodities)")
+	assert.Equal(t, len(commodities), last.total, "total must equal len(commodities) on every call")
+	for _, c := range calls {
+		assert.Equal(t, len(commodities), c.total, "total must be constant across all progress calls")
+		assert.Greater(t, c.completed, 0, "completed must always be positive")
+	}
 }

--- a/internal/model/model_sync_commodities_test.go
+++ b/internal/model/model_sync_commodities_test.go
@@ -1,0 +1,111 @@
+package model
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ananthakumaran/paisa/internal/config"
+	"github.com/ananthakumaran/paisa/internal/model/migration"
+	"github.com/ananthakumaran/paisa/internal/model/price"
+	"github.com/glebarez/sqlite"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func openSyncCommoditiesTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, migration.RunMigrations(db))
+	return db
+}
+
+type trackingPriceProvider struct {
+	current atomic.Int64
+	max     atomic.Int64
+}
+
+func (p *trackingPriceProvider) Name() string {
+	return "tracking-provider"
+}
+
+func (p *trackingPriceProvider) Code() string {
+	return "tracking-provider"
+}
+
+func (p *trackingPriceProvider) Label() string {
+	return "Tracking Provider"
+}
+
+func (p *trackingPriceProvider) Description() string {
+	return "tracking provider for sync concurrency tests"
+}
+
+func (p *trackingPriceProvider) AutoCompleteFields() []price.AutoCompleteField {
+	return nil
+}
+
+func (p *trackingPriceProvider) AutoComplete(*gorm.DB, string, map[string]string) []price.AutoCompleteItem {
+	return []price.AutoCompleteItem{}
+}
+
+func (p *trackingPriceProvider) ClearCache(*gorm.DB) {
+}
+
+func (p *trackingPriceProvider) GetPrices(code string, commodityName string) ([]*price.Price, error) {
+	current := p.current.Add(1)
+	for {
+		maxSeen := p.max.Load()
+		if current <= maxSeen || p.max.CompareAndSwap(maxSeen, current) {
+			break
+		}
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	p.current.Add(-1)
+
+	return []*price.Price{
+		{
+			CommodityType:  config.Stock,
+			CommodityID:    code,
+			CommodityName:  commodityName,
+			Date:           time.Now().UTC(),
+			QuoteCommodity: "INR",
+			Value:          decimal.NewFromInt(1),
+		},
+	}, nil
+}
+
+func TestSyncCommodities_UsesBoundedConcurrentFetching(t *testing.T) {
+	db := openSyncCommoditiesTestDB(t)
+	provider := &trackingPriceProvider{}
+
+	commodities := make([]config.Commodity, 0, 12)
+	for i := 0; i < 12; i++ {
+		commodities = append(commodities, config.Commodity{
+			Name: fmt.Sprintf("Commodity-%d", i),
+			Type: config.Stock,
+			Price: config.Price{
+				Provider: "test-provider",
+				Code:     fmt.Sprintf("C%d", i),
+			},
+		})
+	}
+
+	result, err := syncCommodities(db, commodities, func(string) price.PriceProvider {
+		return provider
+	}, 5)
+	require.NoError(t, err)
+	assert.Empty(t, result.Failures)
+
+	assert.Greater(t, provider.max.Load(), int64(1), "expected concurrent fetches")
+	assert.LessOrEqual(t, provider.max.Load(), int64(5), "must not exceed worker limit")
+
+	var count int64
+	require.NoError(t, db.Model(&price.Price{}).Count(&count).Error)
+	assert.Equal(t, int64(len(commodities)), count)
+}

--- a/internal/model/model_sync_commodities_test.go
+++ b/internal/model/model_sync_commodities_test.go
@@ -99,7 +99,7 @@ func TestSyncCommodities_UsesBoundedConcurrentFetching(t *testing.T) {
 
 	result, err := syncCommodities(db, commodities, func(string) price.PriceProvider {
 		return provider
-	}, 5, nil)
+	}, 5, false, nil)
 	require.NoError(t, err)
 	assert.Empty(t, result.Failures)
 
@@ -165,7 +165,7 @@ func TestSyncCommodities_PassesSinceToProvider(t *testing.T) {
 	getProvider := func(_ string) price.PriceProvider { return stub }
 
 	// First call: no metadata → since must be zero (full history fetch).
-	_, err := syncCommodities(db, commodities, getProvider, 1, nil)
+	_, err := syncCommodities(db, commodities, getProvider, 1, false, nil)
 	require.NoError(t, err)
 	assert.True(t, stub.receivedSince.IsZero(), "since must be zero when no last_price_sync metadata exists")
 
@@ -175,10 +175,16 @@ func TestSyncCommodities_PassesSinceToProvider(t *testing.T) {
 
 	// Second call: since must match the stored timestamp.
 	stub.receivedSince = time.Time{} // reset
-	_, err = syncCommodities(db, commodities, getProvider, 1, nil)
+	_, err = syncCommodities(db, commodities, getProvider, 1, false, nil)
 	require.NoError(t, err)
 	assert.Equal(t, lastSync.UTC().Truncate(time.Second), stub.receivedSince.UTC().Truncate(time.Second),
 		"since must match the last_price_sync metadata value")
+
+	// Force refresh: ignore metadata and fetch full history again.
+	stub.receivedSince = lastSync
+	_, err = syncCommodities(db, commodities, getProvider, 1, true, nil)
+	require.NoError(t, err)
+	assert.True(t, stub.receivedSince.IsZero(), "force refresh must ignore last_price_sync metadata")
 }
 
 // TestSyncCommodities_IncrementalUpsertPreservesHistory verifies that on an
@@ -216,7 +222,7 @@ func TestSyncCommodities_IncrementalUpsertPreservesHistory(t *testing.T) {
 	}
 	getProvider := func(_ string) price.PriceProvider { return stub }
 
-	_, err := syncCommodities(db, commodities, getProvider, 1, nil)
+	_, err := syncCommodities(db, commodities, getProvider, 1, false, nil)
 	require.NoError(t, err)
 
 	var count int64
@@ -235,7 +241,7 @@ func TestSyncCommodities_IncrementalUpsertPreservesHistory(t *testing.T) {
 			QuoteCommodity: "USD",
 		},
 	}
-	_, err = syncCommodities(db, commodities, getProvider, 1, nil)
+	_, err = syncCommodities(db, commodities, getProvider, 1, false, nil)
 	require.NoError(t, err)
 
 	db.Model(&price.Price{}).Count(&count)
@@ -273,7 +279,7 @@ func TestSyncCommodities_ReportsProgress(t *testing.T) {
 		calls = append(calls, struct{ completed, total int }{completed, total})
 	}
 
-	_, err := syncCommodities(db, commodities, getProvider, 1, progressFn)
+	_, err := syncCommodities(db, commodities, getProvider, 1, false, progressFn)
 	require.NoError(t, err)
 
 	assert.Len(t, calls, len(commodities), "progressFn must be called once per commodity")

--- a/internal/model/model_sync_commodities_test.go
+++ b/internal/model/model_sync_commodities_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ananthakumaran/paisa/internal/config"
+	"github.com/ananthakumaran/paisa/internal/model/metadata"
 	"github.com/ananthakumaran/paisa/internal/model/migration"
 	"github.com/ananthakumaran/paisa/internal/model/price"
 	"github.com/glebarez/sqlite"
@@ -56,7 +57,7 @@ func (p *trackingPriceProvider) AutoComplete(*gorm.DB, string, map[string]string
 func (p *trackingPriceProvider) ClearCache(*gorm.DB) {
 }
 
-func (p *trackingPriceProvider) GetPrices(code string, commodityName string) ([]*price.Price, error) {
+func (p *trackingPriceProvider) GetPrices(code string, commodityName string, since time.Time) ([]*price.Price, error) {
 	current := p.current.Add(1)
 	for {
 		maxSeen := p.max.Load()
@@ -108,4 +109,135 @@ func TestSyncCommodities_UsesBoundedConcurrentFetching(t *testing.T) {
 	var count int64
 	require.NoError(t, db.Model(&price.Price{}).Count(&count).Error)
 	assert.Equal(t, int64(len(commodities)), count)
+}
+
+// sincePriceProvider is a stub PriceProvider that records the since argument
+// received during GetPrices so tests can assert its value.
+type sincePriceProvider struct {
+	receivedSince time.Time
+	prices        []*price.Price
+}
+
+func (p *sincePriceProvider) Code() string        { return "since-stub" }
+func (p *sincePriceProvider) Label() string       { return "Since Stub" }
+func (p *sincePriceProvider) Description() string { return "" }
+func (p *sincePriceProvider) AutoCompleteFields() []price.AutoCompleteField {
+	return []price.AutoCompleteField{}
+}
+func (p *sincePriceProvider) AutoComplete(_ *gorm.DB, _ string, _ map[string]string) []price.AutoCompleteItem {
+	return []price.AutoCompleteItem{}
+}
+func (p *sincePriceProvider) ClearCache(_ *gorm.DB) {}
+func (p *sincePriceProvider) GetPrices(_ string, _ string, since time.Time) ([]*price.Price, error) {
+	p.receivedSince = since
+	return p.prices, nil
+}
+
+// TestSyncCommodities_PassesSinceToProvider verifies that syncCommodities reads
+// the last_price_sync metadata value and forwards it as the since argument to
+// GetPrices.  When no metadata exists the zero time is passed (full sync).
+func TestSyncCommodities_PassesSinceToProvider(t *testing.T) {
+	db := openSyncCommoditiesTestDB(t)
+
+	stub := &sincePriceProvider{
+		prices: []*price.Price{
+			{
+				Date:           time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC),
+				CommodityType:  config.MutualFund,
+				CommodityID:    "FUND1",
+				CommodityName:  "TestFund",
+				Value:          decimal.NewFromFloat(100.0),
+				QuoteCommodity: "INR",
+			},
+		},
+	}
+
+	commodities := []config.Commodity{
+		{
+			Name: "TestFund",
+			Type: config.MutualFund,
+			Price: config.Price{
+				Provider: "since-stub",
+				Code:     "FUND1",
+			},
+		},
+	}
+	getProvider := func(_ string) price.PriceProvider { return stub }
+
+	// First call: no metadata → since must be zero (full history fetch).
+	_, err := syncCommodities(db, commodities, getProvider, 1)
+	require.NoError(t, err)
+	assert.True(t, stub.receivedSince.IsZero(), "since must be zero when no last_price_sync metadata exists")
+
+	// Store a last_price_sync timestamp.
+	lastSync := time.Date(2024, 5, 15, 10, 0, 0, 0, time.UTC)
+	require.NoError(t, metadata.Set(db, LastPriceSyncKey, lastSync.Format(time.RFC3339)))
+
+	// Second call: since must match the stored timestamp.
+	stub.receivedSince = time.Time{} // reset
+	_, err = syncCommodities(db, commodities, getProvider, 1)
+	require.NoError(t, err)
+	assert.Equal(t, lastSync.UTC().Truncate(time.Second), stub.receivedSince.UTC().Truncate(time.Second),
+		"since must match the last_price_sync metadata value")
+}
+
+// TestSyncCommodities_IncrementalUpsertPreservesHistory verifies that on an
+// incremental sync (where the provider returns only new prices), previously
+// stored prices are not deleted – they remain in the DB alongside the new rows.
+func TestSyncCommodities_IncrementalUpsertPreservesHistory(t *testing.T) {
+	db := openSyncCommoditiesTestDB(t)
+
+	// First full sync: provider returns two historical prices.
+	firstSyncPrices := []*price.Price{
+		{
+			Date:           time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			CommodityType:  config.Stock,
+			CommodityID:    "AAPL",
+			CommodityName:  "Apple",
+			Value:          decimal.NewFromFloat(180.0),
+			QuoteCommodity: "USD",
+		},
+		{
+			Date:           time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC),
+			CommodityType:  config.Stock,
+			CommodityID:    "AAPL",
+			CommodityName:  "Apple",
+			Value:          decimal.NewFromFloat(181.0),
+			QuoteCommodity: "USD",
+		},
+	}
+	stub := &sincePriceProvider{prices: firstSyncPrices}
+	commodities := []config.Commodity{
+		{
+			Name:  "Apple",
+			Type:  config.Stock,
+			Price: config.Price{Provider: "since-stub", Code: "AAPL"},
+		},
+	}
+	getProvider := func(_ string) price.PriceProvider { return stub }
+
+	_, err := syncCommodities(db, commodities, getProvider, 1)
+	require.NoError(t, err)
+
+	var count int64
+	db.Model(&price.Price{}).Count(&count)
+	assert.Equal(t, int64(2), count, "first full sync should persist 2 rows")
+
+	// Second incremental sync: provider returns only the newest price.
+	// The existing 2 rows must not be deleted.
+	stub.prices = []*price.Price{
+		{
+			Date:           time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC),
+			CommodityType:  config.Stock,
+			CommodityID:    "AAPL",
+			CommodityName:  "Apple",
+			Value:          decimal.NewFromFloat(182.0),
+			QuoteCommodity: "USD",
+		},
+	}
+	_, err = syncCommodities(db, commodities, getProvider, 1)
+	require.NoError(t, err)
+
+	db.Model(&price.Price{}).Count(&count)
+	assert.Equal(t, int64(3), count, "incremental sync must add new prices without removing historical rows")
 }

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -273,14 +273,14 @@ func TestUpsertAllByTypeNameAndID_BackfillsEmptyQuote(t *testing.T) {
 	assert.Equal(t, "INR", stored.QuoteCommodity, "empty QuoteCommodity must be backfilled to default")
 }
 
-// TestUpsertAllByTypeNameAndID_CleansUpCompanionRows verifies that when a
-// provider returns companion entries (e.g., exchange-rate rows) alongside main
-// commodity prices, a subsequent upsert correctly removes stale companion rows
-// rather than allowing them to accumulate.
-func TestUpsertAllByTypeNameAndID_CleansUpCompanionRows(t *testing.T) {
+// TestUpsertAllByTypeNameAndID_PreservesHistoryAcrossSyncs verifies that
+// UpsertAllByTypeNameAndID uses a true UPSERT (no DELETE), so that prices from
+// a previous sync are preserved when a subsequent incremental sync adds new rows
+// for different dates.  This is the expected behavior for incremental price sync.
+func TestUpsertAllByTypeNameAndID_PreservesHistoryAcrossSyncs(t *testing.T) {
 	db := openTestDB(t)
 
-	// Simulate a first Yahoo sync for AAPL: stock prices in USD plus USD→INR exchange rates.
+	// Simulate a first sync for AAPL: one stock price and one exchange-rate entry.
 	firstSync := []*price.Price{
 		{
 			Date:           mustParseDate("2024-01-02"),
@@ -306,7 +306,8 @@ func TestUpsertAllByTypeNameAndID_CleansUpCompanionRows(t *testing.T) {
 	db.Model(&price.Price{}).Count(&count)
 	assert.Equal(t, int64(2), count, "first sync should insert 2 rows")
 
-	// Simulate a second sync; companion rows from the first sync must be replaced, not doubled.
+	// Simulate a second incremental sync returning prices for a newer date.
+	// History from the first sync (2024-01-02) must be preserved.
 	secondSync := []*price.Price{
 		{
 			Date:           mustParseDate("2024-01-03"),
@@ -328,18 +329,62 @@ func TestUpsertAllByTypeNameAndID_CleansUpCompanionRows(t *testing.T) {
 	}
 	require.NoError(t, price.UpsertAllByTypeNameAndID(db, config.Stock, "Apple", "AAPL", secondSync))
 
+	// With UPSERT-only semantics, both sync rows are preserved (4 total).
 	db.Model(&price.Price{}).Count(&count)
-	assert.Equal(t, int64(2), count, "second sync must replace first sync rows, not accumulate")
+	assert.Equal(t, int64(4), count, "incremental sync must preserve history – 4 rows across 2 dates")
 
-	// The exchange rate stored is the one from the second sync.
-	var exRate price.Price
-	require.NoError(t, db.Where("commodity_name = ? AND quote_commodity = ?", "USD", "INR").First(&exRate).Error)
-	assert.True(t, exRate.Value.Equal(decimal.NewFromFloat(83.5)), "exchange rate must reflect the latest sync")
-
-	// Confirm exactly one USD→INR row exists (cleanup worked, no accumulation).
+	// Both exchange-rate rows must be present (one per date).
 	var exRateCount int64
 	db.Model(&price.Price{}).Where("commodity_name = ? AND quote_commodity = ?", "USD", "INR").Count(&exRateCount)
-	assert.Equal(t, int64(1), exRateCount, "must be exactly one exchange-rate row after resync")
+	assert.Equal(t, int64(2), exRateCount, "one exchange-rate row per sync date must be preserved")
+
+	// Verify the newer exchange rate is present.
+	var exRate price.Price
+	require.NoError(t, db.Where("commodity_name = ? AND quote_commodity = ? AND date = ?", "USD", "INR", mustParseDate("2024-01-03")).First(&exRate).Error)
+	assert.True(t, exRate.Value.Equal(decimal.NewFromFloat(83.5)), "exchange rate for 2024-01-03 must match the second sync value")
+}
+
+// TestUpsertAllByTypeNameAndID_UpdatesSameDateRow verifies that when a sync
+// provides a price for a date that already exists in the DB, the existing row
+// is updated in place (UPSERT ON CONFLICT DO UPDATE) rather than duplicated.
+func TestUpsertAllByTypeNameAndID_UpdatesSameDateRow(t *testing.T) {
+	db := openTestDB(t)
+
+	initial := []*price.Price{
+		{
+			Date:           mustParseDate("2024-01-02"),
+			CommodityType:  config.Stock,
+			CommodityID:    "AAPL",
+			CommodityName:  "Apple",
+			Value:          decimal.NewFromFloat(185.0),
+			QuoteCommodity: "USD",
+		},
+	}
+	require.NoError(t, price.UpsertAllByTypeNameAndID(db, config.Stock, "Apple", "AAPL", initial))
+
+	var count int64
+	db.Model(&price.Price{}).Count(&count)
+	assert.Equal(t, int64(1), count)
+
+	// Re-sync the same date with a corrected value.
+	corrected := []*price.Price{
+		{
+			Date:           mustParseDate("2024-01-02"),
+			CommodityType:  config.Stock,
+			CommodityID:    "AAPL",
+			CommodityName:  "Apple",
+			Value:          decimal.NewFromFloat(185.5),
+			QuoteCommodity: "USD",
+		},
+	}
+	require.NoError(t, price.UpsertAllByTypeNameAndID(db, config.Stock, "Apple", "AAPL", corrected))
+
+	db.Model(&price.Price{}).Count(&count)
+	assert.Equal(t, int64(1), count, "re-syncing the same date must update in place, not duplicate")
+
+	var stored price.Price
+	require.NoError(t, db.Where("commodity_name = ?", "Apple").First(&stored).Error)
+	assert.True(t, stored.Value.Equal(decimal.NewFromFloat(185.5)), "value must reflect the corrected price")
 }
 
 // TestSyncResult_DefaultValues verifies that a zero-value SyncResult
@@ -488,4 +533,29 @@ func TestSyncJournal_AccountBalancesRefreshed(t *testing.T) {
 	balancesAfterRollback, err := accountbalance.All(db)
 	require.NoError(t, err)
 	assert.Len(t, balancesAfterRollback, 2, "account_balances must be unchanged after rollback")
+}
+
+// TestFilterSince verifies that price.FilterSince returns only prices on or
+// after the start-of-day of since, and returns all prices when since is zero.
+func TestFilterSince(t *testing.T) {
+	prices := []*price.Price{
+		{Date: mustParseDate("2024-01-01"), CommodityName: "A"},
+		{Date: mustParseDate("2024-01-10"), CommodityName: "B"},
+		{Date: mustParseDate("2024-01-20"), CommodityName: "C"},
+	}
+
+	// Zero since → all prices returned.
+	result := price.FilterSince(prices, time.Time{})
+	assert.Len(t, result, 3, "zero since must return all prices")
+
+	// since = 2024-01-10 at mid-day → prices on or after 2024-01-10.
+	since := time.Date(2024, 1, 10, 14, 30, 0, 0, time.UTC)
+	result = price.FilterSince(prices, since)
+	assert.Len(t, result, 2, "since 2024-01-10 must include prices on and after that date")
+	assert.Equal(t, "B", result[0].CommodityName)
+	assert.Equal(t, "C", result[1].CommodityName)
+
+	// since after all prices → empty slice.
+	result = price.FilterSince(prices, time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	assert.Empty(t, result, "since after all prices must return empty slice")
 }

--- a/internal/model/price/price.go
+++ b/internal/model/price/price.go
@@ -52,34 +52,6 @@ func defaultQuoteCommodity() string {
 
 func UpsertAllByTypeNameAndID(db *gorm.DB, commodityType config.CommodityType, commodityName string, commodityID string, prices []*Price) error {
 	return db.Transaction(func(tx *gorm.DB) error {
-		// Build the complete set of names and IDs to delete.  Providers may
-		// return companion entries (e.g., exchange-rate rows) alongside the
-		// main commodity rows; including them here ensures stale companion
-		// rows are removed on each resync rather than accumulating.
-		nameSet := map[string]struct{}{commodityName: {}}
-		idSet := map[string]struct{}{commodityID: {}}
-		for _, p := range prices {
-			if p.CommodityName != "" {
-				nameSet[p.CommodityName] = struct{}{}
-			}
-			if p.CommodityID != "" {
-				idSet[p.CommodityID] = struct{}{}
-			}
-		}
-		names := make([]string, 0, len(nameSet))
-		for n := range nameSet {
-			names = append(names, n)
-		}
-		ids := make([]string, 0, len(idSet))
-		for id := range idSet {
-			ids = append(ids, id)
-		}
-
-		err := tx.Delete(&Price{}, "commodity_type = ? and (commodity_name IN ? or commodity_id IN ?)", commodityType, names, ids).Error
-		if err != nil {
-			return err
-		}
-
 		dc := defaultQuoteCommodity()
 		for _, price := range deduplicatePricePointers(prices) {
 			if price.QuoteCommodity == "" {
@@ -96,6 +68,25 @@ func UpsertAllByTypeNameAndID(db *gorm.DB, commodityType config.CommodityType, c
 
 		return nil
 	})
+}
+
+// FilterSince returns only the prices whose date falls on or after the
+// start-of-day (UTC) of since.  When since is the zero time all prices are
+// returned unchanged, so callers may pass a zero value to disable filtering.
+func FilterSince(prices []*Price, since time.Time) []*Price {
+	if since.IsZero() {
+		return prices
+	}
+	sinceDay := since.UTC().Truncate(24 * time.Hour)
+	out := make([]*Price, 0, len(prices))
+	for _, p := range prices {
+		// !Before is equivalent to (After || Equal): include prices on sinceDay
+		// itself as well as any later date.
+		if !p.Date.UTC().Before(sinceDay) {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // deduplicatePricePointers returns a new slice with only the last price seen

--- a/internal/model/price/provider.go
+++ b/internal/model/price/provider.go
@@ -1,6 +1,10 @@
 package price
 
-import "gorm.io/gorm"
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
 
 // AutoCompleteItem is a single suggestion returned by a provider's AutoComplete method.
 type AutoCompleteItem struct {
@@ -63,9 +67,12 @@ type PriceProvider interface {
 	// every full sync so stale data is not reused across runs.
 	ClearCache(db *gorm.DB)
 
-	// GetPrices fetches the full price history for the commodity identified by
-	// code (provider-specific format) with the display name commodityName.
-	// Return (nil, err) on failure; return (empty-or-nil slice, nil) when
-	// there is no data available without an underlying error.
-	GetPrices(code string, commodityName string) ([]*Price, error)
+	// GetPrices fetches price history for the commodity identified by code
+	// (provider-specific format) with the display name commodityName.
+	// When since is non-zero, implementations should return only prices on or
+	// after since's start-of-day (UTC); a zero since means fetch the full
+	// history.  Return (nil, err) on failure; return (empty-or-nil slice, nil)
+	// when the provider is reachable but has no data for the requested code –
+	// this is not an error.  Implementations must never call log.Fatal.
+	GetPrices(code string, commodityName string, since time.Time) ([]*Price, error)
 }

--- a/internal/query/posting.go
+++ b/internal/query/posting.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"errors"
+	"time"
 
 	"github.com/ananthakumaran/paisa/internal/config"
 	"github.com/ananthakumaran/paisa/internal/model/posting"
@@ -65,6 +66,11 @@ func (q *Query) BeforeNMonths(n int) *Query {
 
 func (q *Query) UntilToday() *Query {
 	q.context = q.context.Where("date < ?", utils.EndOfToday())
+	return q
+}
+
+func (q *Query) UntilDate(date time.Time) *Query {
+	q.context = q.context.Where("date <= ?", utils.EndOfDay(date))
 	return q
 }
 

--- a/internal/query/posting_test.go
+++ b/internal/query/posting_test.go
@@ -266,6 +266,30 @@ func TestGroupSum_NegativeAmounts(t *testing.T) {
 		"net balance should be 700 after deposit and withdrawal; got %s", sums[0].Amount)
 }
 
+func TestGroupSum_UntilDate(t *testing.T) {
+	db := openTestDB(t)
+	require.NoError(t, db.Create(&posting.Posting{
+		TransactionID: "t1",
+		Date:          time.Date(2024, 1, 10, 0, 0, 0, 0, time.UTC),
+		Account:       "Assets:Checking",
+		Commodity:     "INR",
+		Amount:        decimal.NewFromFloat(1000),
+		Quantity:      decimal.NewFromFloat(1000),
+	}).Error)
+	require.NoError(t, db.Create(&posting.Posting{
+		TransactionID: "t2",
+		Date:          time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+		Account:       "Assets:Checking",
+		Commodity:     "INR",
+		Amount:        decimal.NewFromFloat(-300),
+		Quantity:      decimal.NewFromFloat(-300),
+	}).Error)
+
+	sums := Init(db).AccountPrefix("Assets:Checking").UntilDate(time.Date(2024, 1, 10, 0, 0, 0, 0, time.UTC)).GroupSum()
+	require.Len(t, sums, 1)
+	assert.True(t, decimal.NewFromFloat(1000).Equal(sums[0].Amount))
+}
+
 // TestNotAccountPrefix verifies that NotAccountPrefix excludes matching accounts.
 func TestNotAccountPrefix(t *testing.T) {
 	db := openTestDB(t)

--- a/internal/scraper/local/provider.go
+++ b/internal/scraper/local/provider.go
@@ -76,9 +76,10 @@ func (p *PriceProvider) AutoComplete(_ *gorm.DB, _ string, _ map[string]string) 
 func (p *PriceProvider) ClearCache(_ *gorm.DB) {}
 
 // GetPrices reads the JSON file identified by code (a file path) and returns
-// all price entries found in it.  commodityName is used as a fallback when
-// the file itself does not specify a commodity name.
-func (p *PriceProvider) GetPrices(code string, commodityName string) ([]*price.Price, error) {
+// price entries found in it, filtered to those on or after since (start-of-day
+// UTC).  When since is zero all entries are returned.  commodityName is used
+// as a fallback when the file itself does not specify a commodity name.
+func (p *PriceProvider) GetPrices(code string, commodityName string, since time.Time) ([]*price.Price, error) {
 	path := resolveFilePath(code)
 	log.Infof("Loading local JSON prices from %s", path)
 
@@ -87,7 +88,11 @@ func (p *PriceProvider) GetPrices(code string, commodityName string) ([]*price.P
 		return nil, fmt.Errorf("local-json: cannot read file %q: %w", path, err)
 	}
 
-	return parseLocalPrices(data, commodityName)
+	prices, err := parseLocalPrices(data, commodityName)
+	if err != nil {
+		return nil, err
+	}
+	return price.FilterSince(prices, since), nil
 }
 
 // resolveFilePath makes path absolute relative to the config directory when it

--- a/internal/scraper/metal/provider.go
+++ b/internal/scraper/metal/provider.go
@@ -52,7 +52,7 @@ func (p *PriceProvider) AutoComplete(db *gorm.DB, field string, filter map[strin
 func (p *PriceProvider) ClearCache(db *gorm.DB) {
 }
 
-func (p *PriceProvider) GetPrices(code string, commodityName string) ([]*price.Price, error) {
+func (p *PriceProvider) GetPrices(code string, commodityName string, since time.Time) ([]*price.Price, error) {
 	log.Info("Fetching Metal price history from Purified Bytes")
 	url := fmt.Sprintf("https://india.finbodhi.com/api/metal/%s/price.json", code)
 	resp, err := httpclient.Get(url)
@@ -91,5 +91,5 @@ func (p *PriceProvider) GetPrices(code string, commodityName string) ([]*price.P
 		price := price.Price{Date: date, CommodityType: config.Metal, CommodityID: code, CommodityName: commodityName, Value: data.Close.Div(decimal.NewFromInt(10)), QuoteCommodity: "INR"}
 		prices = append(prices, &price)
 	}
-	return prices, nil
+	return price.FilterSince(prices, since), nil
 }

--- a/internal/scraper/mutualfund/provider.go
+++ b/internal/scraper/mutualfund/provider.go
@@ -1,6 +1,8 @@
 package mutualfund
 
 import (
+	"time"
+
 	"github.com/ananthakumaran/paisa/internal/model/mutualfund/scheme"
 	"github.com/ananthakumaran/paisa/internal/model/price"
 	log "github.com/sirupsen/logrus"
@@ -58,6 +60,10 @@ func (p *PriceProvider) ClearCache(db *gorm.DB) {
 	db.Exec("DELETE FROM schemes")
 }
 
-func (p *PriceProvider) GetPrices(code string, commodityName string) ([]*price.Price, error) {
-	return GetNav(code, commodityName)
+func (p *PriceProvider) GetPrices(code string, commodityName string, since time.Time) ([]*price.Price, error) {
+	prices, err := GetNav(code, commodityName)
+	if err != nil {
+		return nil, err
+	}
+	return price.FilterSince(prices, since), nil
 }

--- a/internal/scraper/nps/provider.go
+++ b/internal/scraper/nps/provider.go
@@ -1,6 +1,8 @@
 package nps
 
 import (
+	"time"
+
 	"github.com/ananthakumaran/paisa/internal/model/nps/scheme"
 	"github.com/ananthakumaran/paisa/internal/model/price"
 	log "github.com/sirupsen/logrus"
@@ -58,6 +60,10 @@ func (p *PriceProvider) ClearCache(db *gorm.DB) {
 	db.Exec("DELETE FROM nps_schemes")
 }
 
-func (p *PriceProvider) GetPrices(code string, commodityName string) ([]*price.Price, error) {
-	return GetNav(code, commodityName)
+func (p *PriceProvider) GetPrices(code string, commodityName string, since time.Time) ([]*price.Price, error) {
+	prices, err := GetNav(code, commodityName)
+	if err != nil {
+		return nil, err
+	}
+	return price.FilterSince(prices, since), nil
 }

--- a/internal/scraper/stock/alphavantage.go
+++ b/internal/scraper/stock/alphavantage.go
@@ -225,6 +225,10 @@ func (p *AlphaVantagePriceProvider) AutoComplete(db *gorm.DB, field string, filt
 func (p *AlphaVantagePriceProvider) ClearCache(db *gorm.DB) {
 }
 
-func (p *AlphaVantagePriceProvider) GetPrices(code string, commodityName string) ([]*price.Price, error) {
-	return getHistory(code, commodityName)
+func (p *AlphaVantagePriceProvider) GetPrices(code string, commodityName string, since time.Time) ([]*price.Price, error) {
+	prices, err := getHistory(code, commodityName)
+	if err != nil {
+		return nil, err
+	}
+	return price.FilterSince(prices, since), nil
 }

--- a/internal/scraper/stock/yahoo.go
+++ b/internal/scraper/stock/yahoo.go
@@ -210,6 +210,10 @@ func (p *YahooPriceProvider) AutoComplete(db *gorm.DB, field string, filter map[
 func (p *YahooPriceProvider) ClearCache(db *gorm.DB) {
 }
 
-func (p *YahooPriceProvider) GetPrices(code string, commodityName string) ([]*price.Price, error) {
-	return GetHistory(code, commodityName)
+func (p *YahooPriceProvider) GetPrices(code string, commodityName string, since time.Time) ([]*price.Price, error) {
+	prices, err := GetHistory(code, commodityName)
+	if err != nil {
+		return nil, err
+	}
+	return price.FilterSince(prices, since), nil
 }

--- a/internal/server/add.go
+++ b/internal/server/add.go
@@ -187,7 +187,7 @@ func appendTransactionAndSync(db *gorm.DB, req AddTransactionRequest) (string, e
 	}
 
 	// Trigger sync
-	Sync(db, SyncRequest{Journal: true})
+	Sync(db, SyncRequest{Journal: true}, nil)
 
 	return entryText, nil
 }

--- a/internal/server/as_of_date.go
+++ b/internal/server/as_of_date.go
@@ -1,0 +1,31 @@
+package server
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/ananthakumaran/paisa/internal/config"
+	"github.com/ananthakumaran/paisa/internal/utils"
+	"github.com/gin-gonic/gin"
+)
+
+func parseAsOfDate(c *gin.Context) (time.Time, bool) {
+	raw := c.Query("as_of_date")
+	today := utils.ToDate(utils.Now())
+	if raw == "" {
+		return today, true
+	}
+
+	asOfDate, err := time.ParseInLocation("2006-01-02", raw, config.TimeZone())
+	if err != nil {
+		RespondError(c, http.StatusBadRequest, ErrCodeInvalidRequest, "invalid as_of_date format, expected YYYY-MM-DD")
+		return time.Time{}, false
+	}
+
+	asOfDate = utils.ToDate(asOfDate)
+	if asOfDate.After(today) {
+		RespondError(c, http.StatusBadRequest, ErrCodeInvalidRequest, "as_of_date cannot be in the future")
+		return time.Time{}, false
+	}
+	return asOfDate, true
+}

--- a/internal/server/as_of_date_test.go
+++ b/internal/server/as_of_date_test.go
@@ -1,0 +1,101 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/ananthakumaran/paisa/internal/model/posting"
+	"github.com/ananthakumaran/paisa/internal/utils"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAsOfDate_InvalidFormatReturns400(t *testing.T) {
+	loadTestConfig(t, false)
+	db := openTestDB(t)
+	router := Build(db, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/assets/balance?as_of_date=2024/02/01", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var envelope map[string]ErrorDetail
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &envelope))
+	assert.Equal(t, ErrCodeInvalidRequest, envelope["error"].Code)
+}
+
+func TestAsOfDate_FutureReturns400(t *testing.T) {
+	loadTestConfig(t, false)
+	utils.SetNow("2024-03-20")
+	defer utils.UnsetNow()
+	db := openTestDB(t)
+	router := Build(db, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/assets/balance?as_of_date=2024-03-21", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var envelope map[string]ErrorDetail
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &envelope))
+	assert.Equal(t, ErrCodeInvalidRequest, envelope["error"].Code)
+}
+
+func TestAsOfDate_FiltersAssetsBalanceAndAccountBalance(t *testing.T) {
+	loadTestConfig(t, false)
+	utils.SetNow("2024-03-20")
+	defer utils.UnsetNow()
+	db := openTestDB(t)
+	router := Build(db, false)
+
+	require.NoError(t, db.Create(&posting.Posting{
+		TransactionID: "t1",
+		Date:          time.Date(2024, 1, 10, 0, 0, 0, 0, time.UTC),
+		Account:       "Assets:Checking",
+		Commodity:     "INR",
+		Amount:        decimal.NewFromInt(1000),
+		Quantity:      decimal.NewFromInt(1000),
+	}).Error)
+	require.NoError(t, db.Create(&posting.Posting{
+		TransactionID: "t2",
+		Date:          time.Date(2024, 3, 10, 0, 0, 0, 0, time.UTC),
+		Account:       "Assets:Checking",
+		Commodity:     "INR",
+		Amount:        decimal.NewFromInt(500),
+		Quantity:      decimal.NewFromInt(500),
+	}).Error)
+
+	assetsReq := httptest.NewRequest(http.MethodGet, "/api/assets/balance?flat=true&as_of_date=2024-02-01", nil)
+	assetsRec := httptest.NewRecorder()
+	router.ServeHTTP(assetsRec, assetsReq)
+	require.Equal(t, http.StatusOK, assetsRec.Code)
+
+	var assetsResp struct {
+		AssetBreakdowns map[string]struct {
+			MarketAmount decimal.Decimal `json:"marketAmount"`
+		} `json:"asset_breakdowns"`
+	}
+	require.NoError(t, json.Unmarshal(assetsRec.Body.Bytes(), &assetsResp))
+	require.Contains(t, assetsResp.AssetBreakdowns, "Assets:Checking")
+	assert.True(t, decimal.NewFromInt(1000).Equal(assetsResp.AssetBreakdowns["Assets:Checking"].MarketAmount))
+
+	account := url.PathEscape("Assets:Checking")
+	accountReq := httptest.NewRequest(http.MethodGet, "/api/account/"+account+"/balance?as_of_date=2024-02-01", nil)
+	accountRec := httptest.NewRecorder()
+	router.ServeHTTP(accountRec, accountReq)
+	require.Equal(t, http.StatusOK, accountRec.Code)
+
+	var accountResp struct {
+		AssetBreakdown struct {
+			MarketAmount decimal.Decimal `json:"marketAmount"`
+		} `json:"asset_breakdown"`
+	}
+	require.NoError(t, json.Unmarshal(accountRec.Body.Bytes(), &accountResp))
+	assert.True(t, decimal.NewFromInt(1000).Equal(accountResp.AssetBreakdown.MarketAmount))
+}

--- a/internal/server/assets/balance.go
+++ b/internal/server/assets/balance.go
@@ -3,6 +3,7 @@ package assets
 import (
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/samber/lo"
 	"github.com/shopspring/decimal"
@@ -41,7 +42,11 @@ type AssetBreakdown struct {
 // GetCheckingBalance returns a breakdown of the current balance for all
 // configured checking accounts.
 func GetCheckingBalance(db *gorm.DB, reportCurrency string) gin.H {
-	result := doGetBalance(db, config.GetConfig().CheckingAccounts, false, reportCurrency)
+	return GetCheckingBalanceAsOf(db, reportCurrency, utils.ToDate(utils.Now()))
+}
+
+func GetCheckingBalanceAsOf(db *gorm.DB, reportCurrency string, asOfDate time.Time) gin.H {
+	result := doGetBalance(db, config.GetConfig().CheckingAccounts, false, reportCurrency, asOfDate)
 	if breakdowns, ok := result["asset_breakdowns"].(map[string]AssetBreakdown); ok {
 		filtered := make(map[string]AssetBreakdown)
 		for k, v := range breakdowns {
@@ -55,17 +60,32 @@ func GetCheckingBalance(db *gorm.DB, reportCurrency string) gin.H {
 }
 
 func GetBalance(db *gorm.DB, reportCurrency string) gin.H {
-	return GetBalanceByMode(db, reportCurrency, false)
+	return GetBalanceByModeAsOf(db, reportCurrency, false, utils.ToDate(utils.Now()))
 }
 
 func GetBalanceByMode(db *gorm.DB, reportCurrency string, flat bool) gin.H {
-	if flat {
-		return doGetBalance(db, []string{"regex:^Assets(:|$)"}, false, reportCurrency)
-	}
-	return doGetBalance(db, []string{"Assets"}, !flat, reportCurrency)
+	return GetBalanceByModeAsOf(db, reportCurrency, flat, utils.ToDate(utils.Now()))
 }
 
-func doGetBalance(db *gorm.DB, patterns []string, rollup bool, reportCurrency string) gin.H {
+func GetBalanceByModeAsOf(db *gorm.DB, reportCurrency string, flat bool, asOfDate time.Time) gin.H {
+	if flat {
+		return doGetBalance(db, []string{"regex:^Assets(:|$)"}, false, reportCurrency, asOfDate)
+	}
+	return doGetBalance(db, []string{"Assets"}, !flat, reportCurrency, asOfDate)
+}
+
+func GetAccountBalanceAsOf(db *gorm.DB, account string, reportCurrency string, asOfDate time.Time) gin.H {
+	postings := query.Init(db).UntilDate(asOfDate).AccountPrefix(account, service.CapitalGainsAccount(account)).All()
+	postings = service.PopulateMarketPriceAt(db, postings, asOfDate)
+	breakdown := ComputeBreakdownAt(db, postings, false, account, asOfDate)
+	if reportCurrency != "" && reportCurrency != config.DefaultCurrency() {
+		breakdowns := convertBreakdownsToReportCurrency(db, map[string]AssetBreakdown{account: breakdown}, reportCurrency, asOfDate)
+		breakdown = breakdowns[account]
+	}
+	return gin.H{"asset_breakdown": breakdown}
+}
+
+func doGetBalance(db *gorm.DB, patterns []string, rollup bool, reportCurrency string, asOfDate time.Time) gin.H {
 	var dbPatterns []string
 	for _, p := range patterns {
 		if strings.HasPrefix(p, "regex:") {
@@ -75,8 +95,8 @@ func doGetBalance(db *gorm.DB, patterns []string, rollup bool, reportCurrency st
 		}
 	}
 	dbPatterns = append(dbPatterns, "Income:CapitalGains")
-	postings := query.Init(db).AccountPrefix(dbPatterns...).All()
-	postings = service.PopulateMarketPrice(db, postings)
+	postings := query.Init(db).UntilDate(asOfDate).AccountPrefix(dbPatterns...).All()
+	postings = service.PopulateMarketPriceAt(db, postings, asOfDate)
 
 	var breakdowns map[string]AssetBreakdown
 	if !rollup {
@@ -101,7 +121,7 @@ func doGetBalance(db *gorm.DB, patterns []string, rollup bool, reportCurrency st
 						}
 						return acc == account
 					})
-					breakdowns[account] = ComputeBreakdown(db, ps, true, account)
+					breakdowns[account] = ComputeBreakdownAt(db, ps, true, account, asOfDate)
 				}
 			} else {
 				group := strings.TrimSuffix(p, ":%")
@@ -113,12 +133,12 @@ func doGetBalance(db *gorm.DB, patterns []string, rollup bool, reportCurrency st
 					return utils.MatchAccount(account, p)
 				})
 				if len(ps) > 0 {
-					breakdowns[group] = ComputeBreakdown(db, ps, true, group)
+					breakdowns[group] = ComputeBreakdownAt(db, ps, true, group, asOfDate)
 				}
 			}
 		}
 	} else {
-		breakdowns = ComputeBreakdowns(db, postings, rollup)
+		breakdowns = ComputeBreakdownsAt(db, postings, rollup, asOfDate)
 
 		// Filter breakdowns to only include those that match the requested patterns.
 		// This prevents internal query accounts like Income:CapitalGains from
@@ -136,7 +156,7 @@ func doGetBalance(db *gorm.DB, patterns []string, rollup bool, reportCurrency st
 	}
 
 	if reportCurrency != "" && reportCurrency != config.DefaultCurrency() {
-		breakdowns = convertBreakdownsToReportCurrency(db, breakdowns, reportCurrency)
+		breakdowns = convertBreakdownsToReportCurrency(db, breakdowns, reportCurrency, asOfDate)
 	}
 	return gin.H{"asset_breakdowns": breakdowns}
 }
@@ -145,9 +165,8 @@ func doGetBalance(db *gorm.DB, patterns []string, rollup bool, reportCurrency st
 // AssetBreakdown by the current exchange rate from the default currency to
 // reportCurrency.  Rate-insensitive fields (XIRR, AbsoluteReturn, BalanceUnits)
 // are left unchanged.  When no rate is available, breakdowns are returned as-is.
-func convertBreakdownsToReportCurrency(db *gorm.DB, breakdowns map[string]AssetBreakdown, reportCurrency string) map[string]AssetBreakdown {
-	today := utils.EndOfToday()
-	rate, ok := service.GetRate(db, config.DefaultCurrency(), reportCurrency, today)
+func convertBreakdownsToReportCurrency(db *gorm.DB, breakdowns map[string]AssetBreakdown, reportCurrency string, asOfDate time.Time) map[string]AssetBreakdown {
+	rate, ok := service.GetRate(db, config.DefaultCurrency(), reportCurrency, utils.EndOfDay(asOfDate))
 	if !ok {
 		return breakdowns
 	}
@@ -179,6 +198,10 @@ func convertBreakdownsToReportCurrency(db *gorm.DB, breakdowns map[string]AssetB
 // accounts.  This is substantially better than the naïve O(A×N) approach of
 // filtering the full postings slice once per group.
 func ComputeBreakdowns(db *gorm.DB, postings []posting.Posting, rollup bool) map[string]AssetBreakdown {
+	return ComputeBreakdownsAt(db, postings, rollup, utils.ToDate(utils.Now()))
+}
+
+func ComputeBreakdownsAt(db *gorm.DB, postings []posting.Posting, rollup bool, asOfDate time.Time) map[string]AssetBreakdown {
 	// Phase 1: identify all breakdown groups and classify leaf vs. parent.
 	accounts := make(map[string]bool)
 	for _, p := range postings {
@@ -218,13 +241,17 @@ func ComputeBreakdowns(db *gorm.DB, postings []posting.Posting, rollup bool) map
 				ps = append(ps, accPostings...)
 			}
 		}
-		result[group] = ComputeBreakdown(db, ps, leaf, group)
+		result[group] = ComputeBreakdownAt(db, ps, leaf, group, asOfDate)
 	}
 
 	return result
 }
 
 func ComputeBreakdown(db *gorm.DB, ps []posting.Posting, leaf bool, group string) AssetBreakdown {
+	return ComputeBreakdownAt(db, ps, leaf, group, utils.ToDate(utils.Now()))
+}
+
+func ComputeBreakdownAt(db *gorm.DB, ps []posting.Posting, leaf bool, group string, asOfDate time.Time) AssetBreakdown {
 	investmentAmount := lo.Reduce(ps, func(acc decimal.Decimal, p posting.Posting, _ int) decimal.Decimal {
 		if utils.IsCheckingAccount(p.Account) || p.Amount.LessThan(decimal.Zero) || service.IsInterest(db, p) || service.IsStockSplit(db, p) || service.IsCapitalGains(p) {
 			return acc
@@ -260,7 +287,7 @@ func ComputeBreakdown(db *gorm.DB, ps []posting.Posting, leaf bool, group string
 	if !investmentAmount.IsZero() {
 		absoluteReturn = marketAmount.Sub(netInvestment).Div(investmentAmount)
 	}
-	originalBalances := computeOriginalBalances(db, psWithoutCapitalGains)
+	originalBalances := computeOriginalBalances(db, psWithoutCapitalGains, asOfDate)
 	return AssetBreakdown{
 		InvestmentAmount: investmentAmount,
 		WithdrawalAmount: withdrawalAmount,
@@ -284,9 +311,9 @@ func ComputeBreakdown(db *gorm.DB, ps []posting.Posting, leaf bool, group string
 //     commodity-name bucket, without any conversion.
 //   - Security postings contribute Quantity × native-unit-price to the price's
 //     quote currency bucket.
-func computeOriginalBalances(db *gorm.DB, ps []posting.Posting) []OriginalCurrencyBalance {
+func computeOriginalBalances(db *gorm.DB, ps []posting.Posting, asOfDate time.Time) []OriginalCurrencyBalance {
 	dc := config.DefaultCurrency()
-	date := utils.EndOfToday()
+	date := utils.EndOfDay(asOfDate)
 
 	// Map commodity → net quantity for securities (priced assets).
 	securityQty := make(map[string]decimal.Decimal)

--- a/internal/server/editor.go
+++ b/internal/server/editor.go
@@ -138,7 +138,7 @@ func SaveFile(db *gorm.DB, file LedgerFile) gin.H {
 		return gin.H{"errors": errors, "saved": false, "message": "Failed to write file"}
 	}
 
-	Sync(db, SyncRequest{Journal: true})
+	Sync(db, SyncRequest{Journal: true}, nil)
 
 	savedFile, err := readLedgerFileWithVersions(dir, filePath)
 	if err != nil {

--- a/internal/server/gain.go
+++ b/internal/server/gain.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"strings"
+	"time"
 
 	"github.com/ananthakumaran/paisa/internal/accounting"
 	"github.com/ananthakumaran/paisa/internal/model/posting"
@@ -47,11 +48,11 @@ func GetGain(db *gorm.DB) gin.H {
 	return gin.H{"gain_breakdown": gains}
 }
 
-func GetAccountGain(db *gorm.DB, account string) gin.H {
+func GetAccountGain(db *gorm.DB, account string, asOfDate time.Time) gin.H {
 	capitalGainsAccount := strings.Replace(account, "Assets", "Income:CapitalGains", 1)
-	postings := query.Init(db).AccountPrefix(account, capitalGainsAccount).All()
-	postings = service.PopulateMarketPrice(db, postings)
-	gain := AccountGain{Account: account, XIRR: service.XIRR(db, postings), NetworthTimeline: computeNetworthTimeline(db, postings, accounting.IsLeafAccount(db, account)), Postings: postings}
+	postings := query.Init(db).UntilDate(asOfDate).AccountPrefix(account, capitalGainsAccount).All()
+	postings = service.PopulateMarketPriceAt(db, postings, asOfDate)
+	gain := AccountGain{Account: account, XIRR: service.XIRR(db, postings), NetworthTimeline: computeNetworthTimeline(db, postings, accounting.IsLeafAccount(db, account), asOfDate), Postings: postings}
 
 	commodities := lo.Uniq(lo.Map(postings, func(p posting.Posting, _ int) string { return p.Commodity }))
 	var portfolio_groups PortfolioAllocationGroups
@@ -60,7 +61,7 @@ func GetAccountGain(db *gorm.DB, account string) gin.H {
 		portfolio_groups = PortfolioAllocationGroups{Commomdities: []string{}, NameAndSecurityType: []PortfolioAggregate{}, SecurityType: []PortfolioAggregate{}, Rating: []PortfolioAggregate{}, Industry: []PortfolioAggregate{}}
 	}
 
-	assetBreakdown := assets.ComputeBreakdown(db, postings, false, account)
+	assetBreakdown := assets.ComputeBreakdownAt(db, postings, false, account, asOfDate)
 
 	return gin.H{"gain_timeline_breakdown": gain, "portfolio_allocation": portfolio_groups, "asset_breakdown": assetBreakdown}
 }

--- a/internal/server/networth.go
+++ b/internal/server/networth.go
@@ -27,7 +27,7 @@ func GetNetworth(db *gorm.DB, reportCurrency string) gin.H {
 	postings := query.Init(db).Like("Assets:%", "Income:CapitalGains:%", "Liabilities:%").UntilToday().All()
 
 	postings = service.PopulateMarketPrice(db, postings)
-	networthTimeline := computeNetworthTimeline(db, postings, false)
+	networthTimeline := computeNetworthTimeline(db, postings, false, utils.ToDate(utils.Now()))
 	xirr := service.XIRR(db, postings)
 	if reportCurrency != "" && reportCurrency != config.DefaultCurrency() {
 		networthTimeline = convertNetworthTimelineToReportCurrency(db, networthTimeline, reportCurrency)
@@ -63,7 +63,7 @@ func convertNetworthTimelineToReportCurrency(db *gorm.DB, timeline []Networth, r
 func GetCurrentNetworth(db *gorm.DB) gin.H {
 	postings := query.Init(db).Like("Assets:%", "Income:CapitalGains:%", "Liabilities:%").UntilToday().All()
 	postings = service.PopulateMarketPrice(db, postings)
-	networthTimeline := computeNetworthTimeline(db, postings, false)
+	networthTimeline := computeNetworthTimeline(db, postings, false, utils.ToDate(utils.Now()))
 	networth := Networth{}
 	if len(networthTimeline) > 0 {
 		networth = networthTimeline[len(networthTimeline)-1]
@@ -121,7 +121,7 @@ func computeNetworth(db *gorm.DB, postings []posting.Posting) Networth {
 	return networth
 }
 
-func computeNetworthTimeline(db *gorm.DB, postings []posting.Posting, computeBalanceUnits bool) []Networth {
+func computeNetworthTimeline(db *gorm.DB, postings []posting.Posting, computeBalanceUnits bool, asOfDate time.Time) []Networth {
 	var networths []Networth
 
 	var p posting.Posting
@@ -139,7 +139,7 @@ func computeNetworthTimeline(db *gorm.DB, postings []posting.Posting, computeBal
 
 	accumulator := make(map[string]RunningSum)
 
-	end := utils.EndOfToday()
+	end := utils.EndOfDay(asOfDate)
 	for start := postings[0].Date; start.Before(end); start = start.AddDate(0, 0, 1) {
 		dayEnd := utils.EndOfDay(start)
 		for len(postings) > 0 && !postings[0].Date.After(dayEnd) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -136,7 +136,7 @@ func Build(db *gorm.DB, enableCompression bool) *gin.Engine {
 		generator.Demo(config.GetConfigDir())
 		config.LoadConfigFile(config.GetConfigPath())
 		// Ignore the result and details; /api/init is a one-shot bootstrap.
-		_, _ = Sync(db, SyncRequest{Journal: true, Prices: true, Portfolios: true})
+		_, _ = Sync(db, SyncRequest{Journal: true, Prices: true, Portfolios: true}, nil)
 		c.JSON(200, gin.H{"success": true})
 	})
 
@@ -150,11 +150,11 @@ func Build(db *gorm.DB, enableCompression bool) *gin.Engine {
 			"journal":    syncRequest.Journal,
 			"prices":     syncRequest.Prices,
 			"portfolios": syncRequest.Portfolios,
-		}, func(_ context.Context) ([]string, error) {
+		}, func(_ context.Context, progress func(int, int)) ([]string, error) {
 			// context.Background() is intentional: the sync job must outlive the
 			// HTTP request.  Using c.Request.Context() would cancel the job as
 			// soon as the 202 response is flushed to the client.
-			result, details := Sync(db, syncRequest)
+			result, details := Sync(db, syncRequest, progress)
 			if success, ok := result["success"].(bool); ok && !success {
 				message, _ := result["message"].(string)
 				if message == "" {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -147,9 +147,10 @@ func Build(db *gorm.DB, enableCompression bool) *gin.Engine {
 		}
 
 		jobID := registry.SubmitDetailed(context.Background(), map[string]any{
-			"journal":    syncRequest.Journal,
-			"prices":     syncRequest.Prices,
-			"portfolios": syncRequest.Portfolios,
+			"journal":      syncRequest.Journal,
+			"prices":       syncRequest.Prices,
+			"force_prices": syncRequest.ForcePrices,
+			"portfolios":   syncRequest.Portfolios,
 		}, func(_ context.Context, progress func(int, int)) ([]string, error) {
 			// context.Background() is intentional: the sync job must outlive the
 			// HTTP request.  Using c.Request.Context() would cancel the job as

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -187,7 +187,11 @@ func Build(db *gorm.DB, enableCompression bool) *gin.Engine {
 	})
 
 	router.GET("/api/assets/balance", func(c *gin.Context) {
-		c.JSON(200, assets.GetBalanceByMode(db, c.Query("report_currency"), c.Query("flat") == "true"))
+		asOfDate, ok := parseAsOfDate(c)
+		if !ok {
+			return
+		}
+		c.JSON(200, assets.GetBalanceByModeAsOf(db, c.Query("report_currency"), c.Query("flat") == "true", asOfDate))
 	})
 
 	router.GET("/api/investment", func(c *gin.Context) {
@@ -198,7 +202,19 @@ func Build(db *gorm.DB, enableCompression bool) *gin.Engine {
 	})
 	router.GET("/api/gain/:account", func(c *gin.Context) {
 		account := c.Param("account")
-		c.JSON(200, GetAccountGain(db, account))
+		asOfDate, ok := parseAsOfDate(c)
+		if !ok {
+			return
+		}
+		c.JSON(200, GetAccountGain(db, account, asOfDate))
+	})
+	router.GET("/api/account/:account/balance", func(c *gin.Context) {
+		account := c.Param("account")
+		asOfDate, ok := parseAsOfDate(c)
+		if !ok {
+			return
+		}
+		c.JSON(200, assets.GetAccountBalanceAsOf(db, account, c.Query("report_currency"), asOfDate))
 	})
 	router.GET("/api/income", func(c *gin.Context) {
 		c.JSON(200, GetIncome(db, parseYearsParam(c.Query("years")), parseUntilYearParam(c.Query("until_year"))))

--- a/internal/server/sync.go
+++ b/internal/server/sync.go
@@ -18,7 +18,12 @@ type SyncRequest struct {
 // response payload together with a (possibly empty) slice of per-step
 // diagnostic messages that should be surfaced to operators via the job
 // Details field.
-func Sync(db *gorm.DB, request SyncRequest) (gin.H, []string) {
+//
+// progressFn, when non-nil, is forwarded to [model.SyncCommodities] so that
+// the caller receives incremental "X of Y commodities" updates while the
+// price-scraper stage is in progress.  Pass nil when progress reporting is
+// not needed (e.g. the one-shot /api/init bootstrap).
+func Sync(db *gorm.DB, request SyncRequest, progressFn func(completed, total int)) (gin.H, []string) {
 	cache.Clear()
 
 	var journalResult model.SyncResult
@@ -37,7 +42,7 @@ func Sync(db *gorm.DB, request SyncRequest) (gin.H, []string) {
 	}
 
 	if request.Prices {
-		commoditiesResult, err := model.SyncCommodities(db)
+		commoditiesResult, err := model.SyncCommodities(db, progressFn)
 		// Accumulate per-commodity failures into details regardless of whether
 		// the overall sync succeeded or failed.
 		details = append(details, commoditiesResult.Failures...)

--- a/internal/server/sync.go
+++ b/internal/server/sync.go
@@ -9,9 +9,10 @@ import (
 )
 
 type SyncRequest struct {
-	Journal    bool `json:"journal"`
-	Prices     bool `json:"prices"`
-	Portfolios bool `json:"portfolios"`
+	Journal     bool `json:"journal"`
+	Prices      bool `json:"prices"`
+	ForcePrices bool `json:"force_prices"`
+	Portfolios  bool `json:"portfolios"`
 }
 
 // Sync executes the requested sync stages synchronously and returns the
@@ -42,7 +43,7 @@ func Sync(db *gorm.DB, request SyncRequest, progressFn func(completed, total int
 	}
 
 	if request.Prices {
-		commoditiesResult, err := model.SyncCommodities(db, progressFn)
+		commoditiesResult, err := model.SyncCommodities(db, request.ForcePrices, progressFn)
 		// Accumulate per-commodity failures into details regardless of whether
 		// the overall sync succeeded or failed.
 		details = append(details, commoditiesResult.Failures...)

--- a/internal/server/sync_test.go
+++ b/internal/server/sync_test.go
@@ -37,7 +37,7 @@ func TestSync_SuccessResponseShape(t *testing.T) {
 	db := openTestDB(t)
 
 	// No sync flags set – all stages are skipped; function must return success.
-	result, details := Sync(db, SyncRequest{})
+	result, details := Sync(db, SyncRequest{}, nil)
 
 	raw, err := json.Marshal(result)
 	require.NoError(t, err)
@@ -82,7 +82,7 @@ func TestSync_JournalFailureResponseShape(t *testing.T) {
 	// branch of Sync without needing a real ledger binary.
 	configWithBrokenJournalPath(t)
 
-	result, _ := Sync(db, SyncRequest{Journal: true})
+	result, _ := Sync(db, SyncRequest{Journal: true}, nil)
 
 	raw, err := json.Marshal(result)
 	require.NoError(t, err)
@@ -219,7 +219,7 @@ func TestIntegration_SyncAsync_FailureStillReturns202(t *testing.T) {
 func TestSync_DetailsReturnedOnSuccess(t *testing.T) {
 	db := openTestDB(t)
 
-	_, details := Sync(db, SyncRequest{})
+	_, details := Sync(db, SyncRequest{}, nil)
 
 	// When no sync stages are requested and there are no investment postings,
 	// WarmXIRRCache is not called, so details is nil (same as empty).

--- a/internal/server/sync_test.go
+++ b/internal/server/sync_test.go
@@ -136,6 +136,42 @@ func TestIntegration_SyncAsync_Returns202WithJobID(t *testing.T) {
 	assert.NotEmpty(t, jobID, "job_id must be non-empty")
 }
 
+// TestIntegration_SyncAsync_ForcePricesMetadata verifies that the optional
+// force_prices request flag is accepted by POST /api/sync and preserved in the
+// submitted job metadata for later inspection by the UI.
+func TestIntegration_SyncAsync_ForcePricesMetadata(t *testing.T) {
+	loadTestConfig(t, false)
+	db := openTestDB(t)
+	router := Build(db, false)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sync",
+		strings.NewReader(`{"prices":true,"force_prices":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	var syncBody map[string]json.RawMessage
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&syncBody))
+	var jobID string
+	require.NoError(t, json.Unmarshal(syncBody["job_id"], &jobID))
+	require.NotEmpty(t, jobID)
+
+	jobReq := httptest.NewRequest(http.MethodGet, "/api/jobs/"+jobID, nil)
+	jobRec := httptest.NewRecorder()
+	router.ServeHTTP(jobRec, jobReq)
+
+	require.Equal(t, http.StatusOK, jobRec.Code)
+
+	var job struct {
+		Metadata map[string]any `json:"metadata"`
+	}
+	require.NoError(t, json.NewDecoder(jobRec.Body).Decode(&job))
+	require.NotNil(t, job.Metadata)
+	assert.Equal(t, true, job.Metadata["force_prices"])
+}
+
 // TestIntegration_GetJob_ReturnsJobStatus verifies that GET /api/jobs/:id
 // returns the job status for a job submitted via POST /api/sync.
 func TestIntegration_GetJob_ReturnsJobStatus(t *testing.T) {

--- a/internal/service/market.go
+++ b/internal/service/market.go
@@ -256,9 +256,13 @@ func GetPrice(db *gorm.DB, commodity string, quantity decimal.Decimal, date time
 }
 
 func PopulateMarketPrice(db *gorm.DB, ps []posting.Posting) []posting.Posting {
-	date := utils.EndOfToday()
+	return PopulateMarketPriceAt(db, ps, utils.ToDate(utils.Now()))
+}
+
+func PopulateMarketPriceAt(db *gorm.DB, ps []posting.Posting, date time.Time) []posting.Posting {
+	asOf := utils.EndOfDay(date)
 	return lo.Map(ps, func(p posting.Posting, _ int) posting.Posting {
-		p.MarketAmount = GetMarketPrice(db, p, date)
+		p.MarketAmount = GetMarketPrice(db, p, asOf)
 		return p
 	})
 }

--- a/internal/service/worker/worker.go
+++ b/internal/service/worker/worker.go
@@ -66,6 +66,12 @@ type Job struct {
 	// are each recorded as a separate entry rather than collapsed into a single
 	// top-level error string.  Present on both successful and failed jobs.
 	Details []string `json:"details,omitempty"`
+	// ItemsCompleted is the number of items processed so far.  Zero until the
+	// job reports its first progress update.
+	ItemsCompleted int `json:"items_completed,omitempty"`
+	// TotalItems is the total number of items to process.  Zero until the job
+	// reports its first progress update.
+	TotalItems int `json:"total_items,omitempty"`
 	// CreatedAt is the wall-clock time at which the job was submitted.
 	CreatedAt time.Time `json:"created_at"`
 	// StartedAt is the wall-clock time at which the job began executing; zero if still pending.
@@ -178,7 +184,12 @@ func (r *Registry) List() []Job {
 // addition to the top-level error so that fine-grained failures (e.g. a price
 // provider failing for one commodity out of many) are observable via the job
 // status API even when the overall job succeeded.
-type DetailedJobFn func(ctx context.Context) (details []string, err error)
+//
+// The progress argument is a thread-safe callback the function may call to
+// report incremental progress.  Each call sets ItemsCompleted and TotalItems
+// on the Job so pollers can display a "X of Y" indicator.  Callers that do
+// not report progress may ignore the argument.
+type DetailedJobFn func(ctx context.Context, progress func(completed, total int)) (details []string, err error)
 
 // SubmitDetailed enqueues fn as a new background job and returns the job ID.
 // It behaves identically to [Registry.Submit] except that fn returns a
@@ -221,7 +232,19 @@ func (r *Registry) runDetailed(ctx context.Context, job *Job, fn DetailedJobFn) 
 
 	log.WithField("job_id", job.ID).Info("worker: job started")
 
-	details, runErr := fn(ctx)
+	// progress is a thread-safe reporter that callers invoke to update the
+	// job's ItemsCompleted and TotalItems fields while the job is running.
+	// Updates are dropped once the job reaches a terminal state.
+	progress := func(completed, total int) {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		if !job.Status.IsTerminal() {
+			job.ItemsCompleted = completed
+			job.TotalItems = total
+		}
+	}
+
+	details, runErr := fn(ctx, progress)
 
 	finished := time.Now().UTC()
 

--- a/internal/service/worker/worker_test.go
+++ b/internal/service/worker/worker_test.go
@@ -336,7 +336,7 @@ func TestRegistry_ConcurrentSubmitAndGet(t *testing.T) {
 // returns a non-empty job ID.
 func TestSubmitDetailed_ReturnsNonEmptyID(t *testing.T) {
 	r := worker.NewRegistry()
-	id := r.SubmitDetailed(context.Background(), nil, func(_ context.Context) ([]string, error) {
+	id := r.SubmitDetailed(context.Background(), nil, func(_ context.Context, _ func(int, int)) ([]string, error) {
 		return nil, nil
 	})
 	assert.NotEmpty(t, id, "SubmitDetailed must return a non-empty job ID")
@@ -347,7 +347,7 @@ func TestSubmitDetailed_ReturnsNonEmptyID(t *testing.T) {
 // Details slice.
 func TestSubmitDetailed_Completed_NoDetails(t *testing.T) {
 	r := worker.NewRegistry()
-	id := r.SubmitDetailed(context.Background(), nil, func(_ context.Context) ([]string, error) {
+	id := r.SubmitDetailed(context.Background(), nil, func(_ context.Context, _ func(int, int)) ([]string, error) {
 		return nil, nil
 	})
 
@@ -370,7 +370,7 @@ func TestSubmitDetailed_Completed_WithDetails(t *testing.T) {
 	r := worker.NewRegistry()
 	want := []string{"commodity A failed", "commodity B failed"}
 
-	id := r.SubmitDetailed(context.Background(), nil, func(_ context.Context) ([]string, error) {
+	id := r.SubmitDetailed(context.Background(), nil, func(_ context.Context, _ func(int, int)) ([]string, error) {
 		return want, nil
 	})
 
@@ -394,7 +394,7 @@ func TestSubmitDetailed_Failed_WithDetails(t *testing.T) {
 	sentinelErr := errors.New("sync failed")
 	want := []string{"XIRR did not converge for account: Assets:Equity:AAPL"}
 
-	id := r.SubmitDetailed(context.Background(), nil, func(_ context.Context) ([]string, error) {
+	id := r.SubmitDetailed(context.Background(), nil, func(_ context.Context, _ func(int, int)) ([]string, error) {
 		return want, sentinelErr
 	})
 
@@ -408,4 +408,45 @@ func TestSubmitDetailed_Failed_WithDetails(t *testing.T) {
 	assert.Equal(t, worker.StatusFailed, job.Status)
 	assert.Equal(t, sentinelErr.Error(), job.Error)
 	assert.Equal(t, want, job.Details, "Details must be stored even when the job fails")
+}
+
+// TestSubmitDetailed_Progress verifies that the progress callback passed to the
+// job function updates ItemsCompleted and TotalItems on the Job while it runs,
+// and that the final values are preserved after the job completes.
+func TestSubmitDetailed_Progress(t *testing.T) {
+	r := worker.NewRegistry()
+
+	ready := make(chan struct{})
+	done := make(chan struct{})
+
+	id := r.SubmitDetailed(context.Background(), nil, func(_ context.Context, progress func(int, int)) ([]string, error) {
+		progress(1, 3)
+		close(ready) // signal that progress has been reported
+		<-done       // wait before finishing
+		progress(3, 3)
+		return nil, nil
+	})
+
+	// Wait until the first progress update is reported.
+	select {
+	case <-ready:
+	case <-time.After(2 * time.Second):
+		t.Fatal("job never reported first progress update")
+	}
+
+	job, ok := r.Get(id)
+	require.True(t, ok)
+	assert.Equal(t, 1, job.ItemsCompleted, "ItemsCompleted must reflect the reported value")
+	assert.Equal(t, 3, job.TotalItems, "TotalItems must reflect the reported value")
+
+	close(done) // allow the job to finish
+
+	assert.Eventually(t, func() bool {
+		j, _ := r.Get(id)
+		return j.Status == worker.StatusCompleted
+	}, 2*time.Second, 5*time.Millisecond, "job must reach Completed")
+
+	job, _ = r.Get(id)
+	assert.Equal(t, 3, job.ItemsCompleted, "ItemsCompleted must be final value after completion")
+	assert.Equal(t, 3, job.TotalItems, "TotalItems must be final value after completion")
 }

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -60,6 +60,7 @@ interface UserConfig {
   provider_debug_http: boolean;
   locale: string;
   journal_path: string;
+  add_journal_path: string;
   display_precision: number;
   db_path: string;
   financial_year_starting_month: number;

--- a/src/lib/account_balance_trend.test.ts
+++ b/src/lib/account_balance_trend.test.ts
@@ -1,0 +1,40 @@
+import dayjs from "dayjs";
+import { describe, expect, it } from "bun:test";
+import { buildTrendPath, filterTrendPoints, trendRangeFromMonths } from "./account_balance_trend";
+import type { Networth } from "./utils";
+
+function point(date: string, balanceAmount: number): Networth {
+  return {
+    date: dayjs(date),
+    investmentAmount: 0,
+    withdrawalAmount: 0,
+    gainAmount: 0,
+    balanceAmount,
+    balanceUnits: 0,
+    netInvestmentAmount: 0
+  };
+}
+
+describe("account balance trend helpers", () => {
+  it("builds a months-based trend range ending on as-of date", () => {
+    const range = trendRangeFromMonths("2026-03-01", 6);
+    expect(range.end).toBe("2026-03-01");
+    expect(range.start).toBe("2025-09-01");
+  });
+
+  it("filters trend points within selected start/end dates", () => {
+    const points = [point("2026-01-01", 100), point("2026-02-01", 200), point("2026-03-01", 250)];
+    const filtered = filterTrendPoints(points, "2026-02-01", "2026-03-01");
+    expect(filtered).toHaveLength(2);
+    expect(filtered[0].date.format("YYYY-MM-DD")).toBe("2026-02-01");
+    expect(filtered[1].date.format("YYYY-MM-DD")).toBe("2026-03-01");
+  });
+
+  it("creates an svg path and last-point marker", () => {
+    const points = [point("2026-01-01", 100), point("2026-01-02", 120), point("2026-01-03", 90)];
+    const output = buildTrendPath(points, 600, 240);
+    expect(output.path.startsWith("M ")).toBe(true);
+    expect(output.path.includes(" L ")).toBe(true);
+    expect(output.marker).not.toBeNull();
+  });
+});

--- a/src/lib/account_balance_trend.ts
+++ b/src/lib/account_balance_trend.ts
@@ -1,0 +1,53 @@
+import dayjs from "dayjs";
+import type { Networth } from "./utils";
+
+export type TrendMarker = { x: number; y: number };
+
+export function trendRangeFromMonths(
+  asOfDate: string,
+  months: number
+): { start: string; end: string } {
+  const end = dayjs(asOfDate).startOf("day");
+  const start = end.subtract(months, "month").startOf("day");
+  return { start: start.format("YYYY-MM-DD"), end: end.format("YYYY-MM-DD") };
+}
+
+export function filterTrendPoints(points: Networth[], start: string, end: string): Networth[] {
+  const startDate = dayjs(start).startOf("day");
+  const endDate = dayjs(end).endOf("day");
+  if (!startDate.isValid() || !endDate.isValid() || endDate.isBefore(startDate)) {
+    return [];
+  }
+  return points.filter((point) => !point.date.isBefore(startDate) && !point.date.isAfter(endDate));
+}
+
+export function buildTrendPath(
+  points: Networth[],
+  width: number,
+  height: number,
+  padding = 20
+): { path: string; marker: TrendMarker | null } {
+  if (points.length === 0) {
+    return { path: "", marker: null };
+  }
+
+  const start = points[0].date.startOf("day");
+  const end = points[points.length - 1].date.endOf("day");
+  const spanDays = Math.max(end.diff(start, "day"), 1);
+
+  const balances = points.map((point) => point.balanceAmount);
+  const minBalance = Math.min(...balances);
+  const maxBalance = Math.max(...balances);
+  const balanceSpan = maxBalance - minBalance || 1;
+
+  const x = (date: dayjs.Dayjs) =>
+    padding + (date.diff(start, "day") / spanDays) * (width - padding * 2);
+  const y = (balance: number) =>
+    height - padding - ((balance - minBalance) / balanceSpan) * (height - padding * 2);
+
+  const segments = points.map(
+    (point, index) => `${index === 0 ? "M" : "L"} ${x(point.date)} ${y(point.balanceAmount)}`
+  );
+  const last = points[points.length - 1];
+  return { path: segments.join(" "), marker: { x: x(last.date), y: y(last.balanceAmount) } };
+}

--- a/src/lib/components/Actions.svelte
+++ b/src/lib/components/Actions.svelte
@@ -9,8 +9,20 @@
   import dayjs from "dayjs";
   import { refresh, now, willRefresh } from "../../store";
   import SyncHistoryOverlay from "./SyncHistoryOverlay.svelte";
+  import QuickAddModal from "./QuickAddModal.svelte";
+  import { ajax } from "$lib/utils";
 
   let showHistory = $state(false);
+  let showQuickAdd = $state(false);
+  let accounts: string[] = $state([]);
+
+  async function openQuickAdd() {
+    if (accounts.length === 0) {
+      const response = await ajax("/api/config");
+      accounts = response.accounts || [];
+    }
+    showQuickAdd = true;
+  }
 
   async function syncWithLoader(request: Record<string, any>) {
     const jobId = await sync(request);
@@ -60,7 +72,18 @@
 
 <div class="is-flex is-align-items-center" style="gap: 0.25rem;">
   <SyncHistoryOverlay bind:open={showHistory} />
+  <QuickAddModal bind:open={showQuickAdd} {accounts} />
 
+  <button
+    class="navbar-action-button"
+    data-tippy-content="<p>Quick Add Transaction</p>"
+    aria-label="Quick Add Transaction"
+    onclick={openQuickAdd}
+  >
+    <span class="icon">
+      <i class="fa-solid fa-circle-plus"></i>
+    </span>
+  </button>
   <button
     class="navbar-action-button sync-history-btn"
     data-tippy-content="<p>Sync History</p>"

--- a/src/lib/components/QuickAddModal.svelte
+++ b/src/lib/components/QuickAddModal.svelte
@@ -1,0 +1,182 @@
+<script lang="ts">
+  import { ajax } from "$lib/utils";
+  import * as toast from "bulma-toast";
+  import dayjs from "dayjs";
+  import { refresh } from "../../store";
+
+  let { open = $bindable(false), accounts = [] }: { open: boolean; accounts: string[] } = $props();
+
+  let date = $state(dayjs().format("YYYY-MM-DD"));
+  let payee = $state("");
+  let narration = $state("");
+  let fromAccount = $state("");
+  let toAccount = $state("");
+  let amount = $state("");
+  let commodity = $state(USER_CONFIG.default_currency || "INR");
+  let isLoading = $state(false);
+
+  async function submit() {
+    if (!date || !fromAccount || !toAccount || !amount || !commodity) {
+      toast.toast({ message: "Please fill all required fields", type: "is-danger" });
+      return;
+    }
+
+    isLoading = true;
+    try {
+      const response = await ajax("/api/transaction/add", {
+        method: "POST",
+        body: JSON.stringify({
+          date,
+          payee,
+          narration,
+          from_account: fromAccount,
+          to_account: toAccount,
+          amount,
+          commodity
+        })
+      });
+
+      if (response.success) {
+        toast.toast({ message: "Transaction added successfully", type: "is-success" });
+        open = false;
+        // Reset form
+        payee = "";
+        narration = "";
+        amount = "";
+        refresh();
+      } else {
+        toast.toast({
+          message: response.error?.message || "Failed to add transaction",
+          type: "is-danger"
+        });
+      }
+    } catch (e: any) {
+      toast.toast({ message: e.message || "An error occurred", type: "is-danger" });
+    } finally {
+      isLoading = false;
+    }
+  }
+</script>
+
+<div class="modal" class:is-active={open}>
+  <div class="modal-background" onclick={() => (open = false)}></div>
+  <div class="modal-card">
+    <header class="modal-card-head">
+      <p class="modal-card-title">Quick Add Transaction</p>
+      <button class="delete" aria-label="close" onclick={() => (open = false)}></button>
+    </header>
+    <section class="modal-card-body">
+      {#if !USER_CONFIG.add_journal_path}
+        <article class="message is-warning is-small">
+          <div class="message-body">
+            <code>add_journal_path</code> is not configured. Please set it in Settings first.
+          </div>
+        </article>
+      {/if}
+
+      <div class="field">
+        <label class="label is-small">Date</label>
+        <div class="control">
+          <input class="input is-small" type="date" bind:value={date} required />
+        </div>
+      </div>
+
+      <div class="field">
+        <label class="label is-small">Payee</label>
+        <div class="control">
+          <input class="input is-small" type="text" bind:value={payee} placeholder="e.g. Amazon" />
+        </div>
+      </div>
+
+      <div class="field">
+        <label class="label is-small">Narration</label>
+        <div class="control">
+          <input
+            class="input is-small"
+            type="text"
+            bind:value={narration}
+            placeholder="e.g. New keyboard"
+          />
+        </div>
+      </div>
+
+      <div class="columns is-mobile mb-0">
+        <div class="column">
+          <div class="field">
+            <label class="label is-small">From Account</label>
+            <div class="control">
+              <input
+                class="input is-small"
+                list="accounts-list"
+                bind:value={fromAccount}
+                placeholder="Search account..."
+                required
+              />
+            </div>
+          </div>
+        </div>
+        <div class="column">
+          <div class="field">
+            <label class="label is-small">To Account</label>
+            <div class="control">
+              <input
+                class="input is-small"
+                list="accounts-list"
+                bind:value={toAccount}
+                placeholder="Search account..."
+                required
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="columns is-mobile">
+        <div class="column">
+          <div class="field">
+            <label class="label is-small">Amount</label>
+            <div class="control">
+              <input
+                class="input is-small"
+                type="text"
+                bind:value={amount}
+                placeholder="0.00"
+                required
+              />
+            </div>
+          </div>
+        </div>
+        <div class="column">
+          <div class="field">
+            <label class="label is-small">Currency</label>
+            <div class="control">
+              <input class="input is-small" type="text" bind:value={commodity} required />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <datalist id="accounts-list">
+        {#each accounts as account}
+          <option value={account}></option>
+        {/each}
+      </datalist>
+    </section>
+    <footer class="modal-card-foot is-justify-content-flex-end">
+      <button class="button is-small" onclick={() => (open = false)}>Cancel</button>
+      <button
+        class="button is-primary is-small {isLoading ? 'is-loading' : ''}"
+        onclick={submit}
+        disabled={!USER_CONFIG.add_journal_path}
+      >
+        Add Transaction
+      </button>
+    </footer>
+  </div>
+</div>
+
+<style lang="scss">
+  .modal-card {
+    max-width: 450px;
+  }
+</style>

--- a/src/lib/components/SyncHistoryOverlay.svelte
+++ b/src/lib/components/SyncHistoryOverlay.svelte
@@ -45,10 +45,10 @@
                     </span>
                     <span>&nbsp;{job.status}</span>
                   </span>
-                  <span class="has-text-grey is-size-7" title={job.id}>
-                    #{job.id.slice(0, 8)}
+                  <span class="has-text-grey is-size-7" title={job?.id}>
+                    #{job?.id?.slice(0, 8) ?? "unknown"}
                   </span>
-                  {#if job.metadata}
+                  {#if job?.metadata}
                     <span class="has-text-weight-semibold is-size-7 ml-2">
                       {#if job.metadata.journal}Journal{/if}
                       {#if job.metadata.prices}{job.metadata.journal ? " + " : ""}Prices{/if}

--- a/src/lib/components/SyncHistoryOverlay.svelte
+++ b/src/lib/components/SyncHistoryOverlay.svelte
@@ -78,6 +78,20 @@
                 </div>
               </div>
 
+              {#if job.status === "running" && job.total_items && job.total_items > 0}
+                <div class="mt-2">
+                  <progress
+                    class="progress is-info is-small mb-1"
+                    value={job.items_completed ?? 0}
+                    max={job.total_items}
+                    aria-label="Sync progress"
+                  ></progress>
+                  <span class="is-size-7 has-text-grey">
+                    {job.items_completed ?? 0} of {job.total_items} commodities
+                  </span>
+                </div>
+              {/if}
+
               {#if job.error}
                 <div
                   class="mt-2 p-2 has-background-danger-light has-text-danger-dark is-size-7 sync-error-snippet"

--- a/src/lib/components/SyncingIndicator.svelte
+++ b/src/lib/components/SyncingIndicator.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { fade } from "svelte/transition";
-  import { isJobRunning } from "$lib/stores/jobs";
+  import { isJobRunning, runningJob } from "$lib/stores/jobs";
 </script>
 
 {#if $isJobRunning}
@@ -14,7 +14,13 @@
     <span class="icon is-small">
       <i class="fas fa-rotate fa-spin" aria-hidden="true"></i>
     </span>
-    <span class="syncing-label is-hidden-mobile">Syncing…</span>
+    {#if $runningJob?.total_items && $runningJob.total_items > 0}
+      <span class="syncing-label is-hidden-mobile">
+        {$runningJob.items_completed ?? 0}&nbsp;/&nbsp;{$runningJob.total_items}
+      </span>
+    {:else}
+      <span class="syncing-label is-hidden-mobile">Syncing…</span>
+    {/if}
   </span>
 {/if}
 

--- a/src/lib/components/ThemeSwitcher.svelte
+++ b/src/lib/components/ThemeSwitcher.svelte
@@ -18,9 +18,7 @@
   }
 
   const toggle = () => {
-    if (refresh()) {
-      setTheme(theme === "light" ? "dark" : "light");
-    }
+    setTheme(theme === "light" ? "dark" : "light");
   };
 
   const reflectPreference = () => {

--- a/src/lib/config-sections.ts
+++ b/src/lib/config-sections.ts
@@ -19,7 +19,13 @@ export const CONFIG_GROUPS: ConfigGroup[] = [
         id: "core-setup",
         label: "Core Setup",
         icon: "fa-gear",
-        schemaKeys: ["journal_path", "db_path", "sheets_directory", "ledger_cli"],
+        schemaKeys: [
+          "journal_path",
+          "add_journal_path",
+          "db_path",
+          "sheets_directory",
+          "ledger_cli"
+        ],
         description: "Journal paths, ledger engine, and fundamental options"
       },
       {

--- a/src/lib/stores/jobs.test.ts
+++ b/src/lib/stores/jobs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, beforeEach } from "bun:test";
 import { get } from "svelte/store";
-import { jobs, jobsList, isJobRunning } from "./jobs";
+import { jobs, jobsList, isJobRunning, runningJob } from "./jobs";
 import type { Job } from "$lib/utils";
 
 function makeJob(overrides: Partial<Job> = {}): Job {
@@ -139,5 +139,48 @@ describe("isJobRunning derived store", () => {
     expect(get(isJobRunning)).toBe(true);
     jobs.updateById("test-id-1", { status: "completed" });
     expect(get(isJobRunning)).toBe(false);
+  });
+});
+
+describe("runningJob derived store", () => {
+  beforeEach(() => {
+    jobs.reset();
+  });
+
+  test("null when store is empty", () => {
+    expect(get(runningJob)).toBeNull();
+  });
+
+  test("returns the pending job", () => {
+    const job = makeJob({ status: "pending" });
+    jobs.upsert(job);
+    expect(get(runningJob)).toEqual(job);
+  });
+
+  test("returns the running job", () => {
+    const job = makeJob({ status: "running" });
+    jobs.upsert(job);
+    expect(get(runningJob)).toEqual(job);
+  });
+
+  test("null when all jobs are terminal", () => {
+    jobs.upsert(makeJob({ id: "a", status: "completed" }));
+    jobs.upsert(makeJob({ id: "b", status: "failed" }));
+    expect(get(runningJob)).toBeNull();
+  });
+
+  test("exposes items_completed and total_items from running job", () => {
+    const job = makeJob({ status: "running", items_completed: 3, total_items: 10 });
+    jobs.upsert(job);
+    const running = get(runningJob);
+    expect(running?.items_completed).toBe(3);
+    expect(running?.total_items).toBe(10);
+  });
+
+  test("updates to null after job moves to completed", () => {
+    jobs.upsert(makeJob({ status: "running" }));
+    expect(get(runningJob)).not.toBeNull();
+    jobs.updateById("test-id-1", { status: "completed" });
+    expect(get(runningJob)).toBeNull();
   });
 });

--- a/src/lib/stores/jobs.ts
+++ b/src/lib/stores/jobs.ts
@@ -15,6 +15,7 @@ export function createJobsStore() {
      * Use this when the API returns a complete Job object.
      */
     upsert(job: Job): void {
+      if (!job || !job.id) return;
       update((current) => ({ ...current, [job.id]: job }));
     },
 

--- a/src/lib/stores/jobs.ts
+++ b/src/lib/stores/jobs.ts
@@ -65,3 +65,14 @@ export const jobsList = derived(jobs, ($jobs) =>
 export const isJobRunning = derived(jobs, ($jobs) =>
   Object.values($jobs).some((j) => j.status === "pending" || j.status === "running")
 );
+
+/**
+ * The first tracked job that is currently in a non-terminal state
+ * (pending or running), or null when no such job exists.
+ * Useful for displaying per-job progress in the navbar.
+ */
+export const runningJob = derived(
+  jobs,
+  ($jobs) =>
+    Object.values($jobs).find((j) => j.status === "pending" || j.status === "running") ?? null
+);

--- a/src/lib/sync.test.ts
+++ b/src/lib/sync.test.ts
@@ -264,6 +264,28 @@ describe("startPolling — error handling and retry", () => {
 
     expect(callCount).toBe(5);
   });
+
+  test("stops polling and marks job as failed on 404 error", async () => {
+    const fetchJob = mock(async (_id: string): Promise<Job> => {
+      const err = new Error("Not found") as any;
+      err.status = 404;
+      throw err;
+    });
+
+    // Seed the store with a running job so we can see it change to failed
+    jobs.upsert(makeJob({ id: "test-job-1", status: "running" }));
+
+    startPolling("test-job-1", undefined, { ...fastOptions, fetchJob });
+
+    await Bun.sleep(50);
+
+    const snap = jobs.snapshot();
+    expect(snap["test-job-1"].status).toBe("failed");
+    expect(snap["test-job-1"].error).toContain("Job not found on server");
+
+    // Should stop polling immediately (only 1 call)
+    expect(fetchJob).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("startPolling — failure toast deduplication", () => {

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -124,7 +124,14 @@ export function startPolling(
       }
 
       setTimeout(poll, intervalMs);
-    } catch (_err) {
+    } catch (err: any) {
+      if (err.status === 404) {
+        jobs.updateById(jobId, {
+          status: "failed",
+          error: "Job not found on server (it may have expired or the server restarted)"
+        });
+        return;
+      }
       consecutiveErrors++;
       if (consecutiveErrors >= maxErrors) {
         return;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -549,6 +549,8 @@ export interface Job {
   status: JobStatus;
   error?: string;
   details?: string[];
+  items_completed?: number;
+  total_items?: number;
   created_at: string;
   started_at?: string;
   finished_at?: string;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -981,10 +981,26 @@ export async function ajax(
     loading.set(false);
   }
 
-  if (response.status == 401 && route != "/api/ping") {
-    logout();
-    await goto("/login");
-    error(401, "Unauthorized");
+  if (!response.ok) {
+    if (response.status == 401 && route != "/api/ping") {
+      logout();
+      await goto("/login");
+      error(401, "Unauthorized");
+    }
+    let errorObj;
+    try {
+      errorObj = JSON.parse(body);
+    } catch (e) {
+      errorObj = { error: { message: body || response.statusText } };
+    }
+    const message =
+      errorObj.error?.message ||
+      errorObj.message ||
+      `Request failed with status ${response.status}`;
+    const err = new Error(message) as any;
+    err.status = response.status;
+    err.body = errorObj;
+    throw err;
   }
 
   return JSON.parse(body, (key, value) => {

--- a/src/routes/(app)/assets/balance/+page.svelte
+++ b/src/routes/(app)/assets/balance/+page.svelte
@@ -69,14 +69,20 @@
               {/if}
             {/if}
             <div class="control">
-              <label class="label is-size-7 mb-1" for="assets-balance-as-of">View as of</label>
-              <input
-                id="assets-balance-as-of"
-                class="input is-small"
-                type="date"
-                bind:value={asOfDate}
-                onchange={() => fetchBreakdowns()}
-              />
+              <div class="field mb-0 is-flex is-align-items-center">
+                <label
+                  class="label is-size-7 mb-0 mr-2"
+                  for="assets-balance-as-of"
+                  style="min-width: fit-content;">View as of</label
+                >
+                <input
+                  id="assets-balance-as-of"
+                  class="input is-small"
+                  type="date"
+                  bind:value={asOfDate}
+                  onchange={() => fetchBreakdowns()}
+                />
+              </div>
             </div>
             <div class="control">
               <div class="field mb-0">

--- a/src/routes/(app)/assets/balance/+page.svelte
+++ b/src/routes/(app)/assets/balance/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import AssetsBalance from "$lib/components/AssetsBalance.svelte";
   import { downloadAssetBalanceCSV, downloadAssetBalanceExcel } from "$lib/export";
-  import { ajax, type AssetBreakdown } from "$lib/utils";
+  import { ajax, now, type AssetBreakdown } from "$lib/utils";
+  import dayjs from "dayjs";
   import { onMount } from "svelte";
 
   let breakdowns: Record<string, AssetBreakdown> = $state({});
@@ -10,10 +11,12 @@
   let flatAccounts = $state(false);
   let filterInactive = $state(true);
   let filterZero = $state(true);
+  let asOfDate = $state(now().format("YYYY-MM-DD"));
 
   async function fetchBreakdowns() {
     const params = new URLSearchParams();
     if (reportCurrency) params.set("report_currency", reportCurrency);
+    params.set("as_of_date", asOfDate);
     const query = params.toString();
     ({ asset_breakdowns: breakdowns } = await ajax(
       query ? `/api/assets/balance?${query}` : "/api/assets/balance"
@@ -65,6 +68,16 @@
                 </p>
               {/if}
             {/if}
+            <div class="control">
+              <label class="label is-size-7 mb-1" for="assets-balance-as-of">View as of</label>
+              <input
+                id="assets-balance-as-of"
+                class="input is-small"
+                type="date"
+                bind:value={asOfDate}
+                onchange={() => fetchBreakdowns()}
+              />
+            </div>
             <div class="control">
               <div class="field mb-0">
                 <input
@@ -126,6 +139,11 @@
             </p>
           </div>
         </div>
+      </div>
+      <div class="column is-12 pb-0">
+        <p class="is-size-7 has-text-grey">
+          Balances as of {dayjs(asOfDate).format("MMM D, YYYY")}
+        </p>
       </div>
       <div class="column is-12 pb-0">
         <AssetsBalance {breakdowns} {filterInactive} {filterZero} indent={!flatAccounts} />

--- a/src/routes/(app)/assets/gain/[slug]/+page.svelte
+++ b/src/routes/(app)/assets/gain/[slug]/+page.svelte
@@ -12,9 +12,16 @@
     type PortfolioAggregate,
     type AssetBreakdown,
     formatPercentage,
-    formatFloatUptoPrecision
+    formatFloatUptoPrecision,
+    now
   } from "$lib/utils";
+  import {
+    buildTrendPath,
+    filterTrendPoints,
+    trendRangeFromMonths
+  } from "$lib/account_balance_trend";
   import _ from "lodash";
+  import dayjs from "dayjs";
   import { onMount, onDestroy } from "svelte";
   import type { PageData } from "./$types";
   import PostingCard from "$lib/components/PostingCard.svelte";
@@ -49,13 +56,26 @@
     portfolioR: any = $state(null),
     industryR: any = $state(null),
     ratingR: any = $state(null);
+  let asOfDate = $state(now().format("YYYY-MM-DD"));
+  let showTrend = $state(false);
+  let trendMonths = $state(6);
+  const initialTrendRange = trendRangeFromMonths(now().format("YYYY-MM-DD"), 6);
+  let trendStart = $state(initialTrendRange.start);
+  let trendEnd = $state(initialTrendRange.end);
+  const trendSvgWidth = 900;
+  const trendSvgHeight = 260;
 
-  onDestroy(async () => {
-    destroyCallback();
-  });
+  function applyTrendPreset(months: number) {
+    trendMonths = months;
+    const range = trendRangeFromMonths(asOfDate, months);
+    trendStart = range.start;
+    trendEnd = range.end;
+  }
 
-  onMount(async () => {
-    const gainResult = await ajax("/api/gain/:name", null, data);
+  async function fetchAccountGain() {
+    const gainResult = await ajax(
+      `/api/gain/${encodeURIComponent(data.name)}?as_of_date=${encodeURIComponent(asOfDate)}`
+    );
     gain = gainResult.gain_timeline_breakdown;
     assetBreakdown = gainResult.asset_breakdown;
     ({ name_and_security_type, security_type, rating, industry, commodities } =
@@ -67,6 +87,7 @@
       .reverse()
       .take(100)
       .value();
+    destroyCallback();
     destroyCallback = renderAccountOverview(
       gain.networthTimeline,
       gain.postings,
@@ -104,6 +125,14 @@
     nameAndSecurityTypeEmpty = name_and_security_type.length === 0;
     ratingEmpty = rating.length === 0;
     industryEmpty = industry.length === 0;
+  }
+
+  onDestroy(async () => {
+    destroyCallback();
+  });
+
+  onMount(async () => {
+    await fetchAccountGain();
   });
 
   $effect(() => {
@@ -114,6 +143,12 @@
       portfolioR(filterCommodityBreakdowns(name_and_security_type, selectedCommodities), color);
     }
   });
+
+  let trendPoints = $derived(
+    gain?.networthTimeline ? filterTrendPoints(gain.networthTimeline, trendStart, trendEnd) : []
+  );
+  let trendPath = $derived(buildTrendPath(trendPoints, trendSvgWidth, trendSvgHeight));
+  let trendCurrentBalance = $derived(_.last(trendPoints)?.balanceAmount ?? null);
 </script>
 
 <section class="section">
@@ -192,6 +227,10 @@
                 >
               </div>
               <div class="ml-3">
+                <span class="mr-1 is-size-7 has-text-grey">As of</span>
+                <span class="has-text-weight-bold">{dayjs(asOfDate).format("MMM D, YYYY")}</span>
+              </div>
+              <div class="ml-3">
                 <span class="mr-1 is-size-7 has-text-grey">Withdrawal</span>
                 <span class="has-text-weight-bold">{formatCurrency(overview.withdrawalAmount)}</span
                 >
@@ -213,6 +252,79 @@
           </div>
         {/if}
         <LegendCard {legends} clazz="mb-2" />
+        <div class="box p-3 mb-2">
+          <div class="field is-grouped is-grouped-multiline mb-2">
+            <div class="control">
+              <label class="label is-size-7 mb-1" for="account-balance-as-of">View as of</label>
+              <input
+                id="account-balance-as-of"
+                class="input is-small"
+                type="date"
+                bind:value={asOfDate}
+                onchange={async () => {
+                  applyTrendPreset(trendMonths);
+                  await fetchAccountGain();
+                }}
+              />
+            </div>
+            <div class="control">
+              <button
+                class="button is-small is-light mt-5"
+                onclick={() => (showTrend = !showTrend)}
+              >
+                {showTrend ? "Hide Trend" : "View Trend"}
+              </button>
+            </div>
+          </div>
+          {#if showTrend}
+            <div class="field is-grouped is-grouped-multiline mb-2">
+              <div class="control">
+                <button
+                  class="button is-small {trendMonths === 6 ? 'is-link' : 'is-light'}"
+                  onclick={() => applyTrendPreset(6)}
+                >
+                  6M
+                </button>
+              </div>
+              <div class="control">
+                <button
+                  class="button is-small {trendMonths === 12 ? 'is-link' : 'is-light'}"
+                  onclick={() => applyTrendPreset(12)}
+                >
+                  12M
+                </button>
+              </div>
+              <div class="control">
+                <input class="input is-small" type="date" bind:value={trendStart} />
+              </div>
+              <div class="control">
+                <input class="input is-small" type="date" bind:value={trendEnd} />
+              </div>
+            </div>
+            {#if trendPoints.length > 1}
+              <svg viewBox="0 0 {trendSvgWidth} {trendSvgHeight}" width="100%" height="280">
+                <path d={trendPath.path} fill="none" stroke={COLORS.primary} stroke-width="2" />
+                {#if trendPath.marker}
+                  <circle
+                    cx={trendPath.marker.x}
+                    cy={trendPath.marker.y}
+                    r="4"
+                    fill={COLORS.gain}
+                  />
+                {/if}
+              </svg>
+              {#if trendCurrentBalance !== null}
+                <p class="is-size-7 has-text-grey">
+                  Current balance marker: {formatCurrency(trendCurrentBalance)}
+                </p>
+              {/if}
+            {:else}
+              <p class="is-size-7 has-text-grey">
+                No trend data available for selected date range.
+              </p>
+            {/if}
+          {/if}
+        </div>
         <div class="box">
           <svg id="d3-account-timeline-breakdown" width="100%" height="450" />
         </div>

--- a/src/routes/(app)/ledger/price/+page.svelte
+++ b/src/routes/(app)/ledger/price/+page.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
   import ValueChange from "$lib/components/ValueChange.svelte";
+  import { sync, startPolling } from "$lib/sync";
   import { ajax, formatCurrency, type Price, type PriceFilters } from "$lib/utils";
   import { toast } from "bulma-toast";
   import _ from "lodash";
   import { onMount } from "svelte";
   import VirtualList from "svelte-tiny-virtual-list";
   import PriceExportModal from "$lib/components/PriceExportModal.svelte";
+  import { refresh } from "../../../../store";
 
   type HistoryMode = "latest" | "all";
 
@@ -83,6 +85,15 @@
       });
     }
     await Promise.all([fetchPrice(), loadFilterOptions()]);
+  }
+
+  async function forceRefreshPrices() {
+    const jobId = await sync({ prices: true, force_prices: true });
+    if (!jobId) return;
+
+    startPolling(jobId, async () => {
+      await Promise.all([refresh(), loadFilterOptions(), fetchPrice()]);
+    });
   }
 
   async function fetchPrice() {
@@ -170,6 +181,17 @@
                   <i class="fas fa-trash-can"></i>
                 </span>
                 <span>Clear Price Cache</span>
+              </button>
+            </p>
+            <p class="control">
+              <button
+                class="button is-small is-link invertable is-light"
+                onclick={(_e) => forceRefreshPrices()}
+              >
+                <span class="icon is-small">
+                  <i class="fas fa-rotate"></i>
+                </span>
+                <span>Force Refresh</span>
               </button>
             </p>
             <p class="control">


### PR DESCRIPTION
This pull request introduces major improvements to the commodity price sync system, focusing on incremental updates, parallel and provider-aware fetching, and enhanced progress reporting. The changes significantly optimize sync performance, preserve historical price data, and provide granular feedback to users during long-running sync jobs. Additionally, the database upsert logic is refactored to avoid data loss during incremental syncs, and the UI/API is updated to reflect these enhancements.

**Incremental and Granular Price Sync:**

- Sync jobs now perform incremental (delta) updates, fetching only new prices since the last sync and preserving historical data. Users can force a full resync when needed. The upsert logic (`UpsertAllByTypeNameAndID`) now uses true UPSERT semantics, updating existing rows in place and never deleting old data. 
**Performance and Provider-aware Throttling:**

- The sync process now orchestrates commodity fetches in parallel using a bounded worker pool (5 concurrent fetches), grouping commodities by provider, and applying per-provider rate limits. Providers with strict throttling are paced independently, improving total sync speed without overloading APIs. 
**Granular Progress Reporting:**

- Sync jobs report per-commodity progress, exposing `items_completed` and `total_items` fields via API and UI. The UI displays progress bars and numeric indicators during syncs, providing real-time feedback.

**Testing and Documentation:**

- New and updated tests verify incremental sync behavior, UPSERT semantics, and correct filtering of prices by date. Documentation is updated to describe the new force-refresh feature and incremental sync behavior. 

**Codebase and API Adjustments:**

- Refactors `SyncCommodities` to accept new parameters and updates all call sites. TypeScript and store definitions are updated to reflect new job fields.
---

**Incremental sync and data preservation:**
- Sync jobs now fetch only new prices since the last sync, preserving all historical price data and enabling full resyncs via a "Force Refresh" option in the UI and API. 
- The upsert logic for prices now uses a true UPSERT (INSERT ... ON CONFLICT DO UPDATE), updating existing rows for the same date and never deleting historical rows. 
**Performance and provider throttling:**
- Commodity price syncs are now parallelized with a bounded worker pool and grouped by provider, applying per-provider throttling based on provider metadata.

**Granular progress reporting:**
- Sync jobs expose per-commodity progress via new API fields, with UI enhancements showing numeric progress and progress bars during syncs.

**Testing and documentation:**
- Tests added/updated to verify incremental sync, UPSERT semantics, and date filtering. Documentation updated for new features and usage. 
**Codebase and API adjustments:**
- Refactored `SyncCommodities` signature and updated related code, including TypeScript interfaces and stores for job progress.