### PR TITLE
feat: rebrand to Paisa+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 #### Features
 
+- **Branding update to Paisa+** — Updated desktop/web branding strings and metadata from "Paisa" to "Paisa+" and aligned regression config fixtures with the new schema title/description.
+ 
 - **Fix More → Logs runtime errors** — Resolved a Logs page failure caused by Workbox navigation fallback and fragile client rendering.
   - Updated PWA `navigateFallback` to `/index.html` so Workbox always serves a precached navigation shell (avoids `non-precached-url` for `/`).
   - Hardened `/more/logs` rendering by removing direct `window` access in markup, guarding virtualized rows, and safely formatting log timestamps.
@@ -37,6 +39,7 @@
   - Backend now returns `original_amount` field on each posting, preserving the amount in the original commodity before any conversion. Frontend toggles between using `amount` (converted to default) and `original_amount` (native commodity) for all calculations and charts.
   - In actual currency view, dimensions are grouped by both category/payee/account AND commodity, so mixed-currency spending is shown separately — e.g., "Groceries" becomes "Groceries (USD)" and "Groceries (EUR)" if both exist.
   - No server roundtrip on currency toggle — all amounts are pre-calculated and sent with each posting.
+
 
 - **MoM Analysis: client-side currency conversion** — Added a "Currency" selector to the MoM analysis page control panel. On load, the page fetches latest FX rates for all configured currency pairs from the new `GET /api/expense/latest-rates` endpoint and stores them locally. Switching currencies instantly re-derives all charts and tables via a `$derived` converted postings layer — no extra network request on each switch. The new backend endpoint (`GetLatestRates`) returns a `rates[base][quote]` map plus the default currency so the UI can build the selector and apply conversions without server-side re-processing.
 

--- a/desktop/wails.json
+++ b/desktop/wails.json
@@ -1,6 +1,7 @@
 {
-  "name": "Paisa",
-  "outputfilename": "Paisa",
+  "$schema": "https://wails.io/schemas/config.v2.json",
+  "name": "Paisa+",
+  "outputfilename": "Paisa+",
   "frontend:install": "",
   "frontend:build": "",
   "author": {
@@ -8,8 +9,8 @@
     "email": "ananthakumaran@gmail.com"
   },
   "Info": {
-    "companyName": "Paisa",
-    "productName": "Paisa",
+    "companyName": "Paisa+",
+    "productName": "Paisa+",
     "productVersion": "0.7.4",
     "copyright": "Copyright © 2022 - 2025 Anantha Kumaran; Copyright © 2026 nextxm contributors",
     "comments": "Fork of ananthakumaran/paisa, maintained at github.com/nextxm/paisa (GNU AGPL-3.0-or-later)"

--- a/internal/config/schema.json
+++ b/internal/config/schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://nextxm.github.io/paisa/schema.json",
-  "title": "Paisa",
-  "description": "Paisa configuration",
+  "title": "Paisa+",
+  "description": "Paisa+ configuration",
   "type": "object",
   "properties": {
     "journal_path": {

--- a/src/app.html
+++ b/src/app.html
@@ -7,19 +7,19 @@
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="apple-mobile-web-app-title" content="Paisa" />
+    <meta name="apple-mobile-web-app-title" content="Paisa+" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="apple-touch-icon" href="/pwa-192x192.png" />
     <meta name="robots" content="noindex, nofollow" />
     <meta
       name="description"
-      content="Paisa is an open source personal finance manager. It builds on top of the ledger double entry accounting tool."
+      content="Paisa+ is an open source personal finance manager. It builds on top of the ledger double entry accounting tool."
     />
     <link
       rel="icon"
       href="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22256%22%20height%3D%22256%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cg%3E%3Cg%20transform%3D%22rotate%28360%29%22%20transform-origin%3D%2212%2012%22%3E%3Cpath%20d%3D%22M12%2012Z%22%20fill%3D%22none%22%20stroke%3D%22%23b388ff%22%20stroke-width%3D%224%22%20stroke-linecap%3D%22round%22%3E%3C%2Fpath%3E%3C%2Fg%3E%3C%2Fg%3E%3Cg%3E%3Cg%20transform%3D%22rotate%280%29%22%20transform-origin%3D%2212%2012%22%3E%3Cpath%20d%3D%22M%2021.510565162951536%208.909830056250526%20A%2010%2010%200%200%200%2012%206%22%20fill%3D%22none%22%20stroke%3D%22%23aeea00%22%20stroke-width%3D%224%22%3E%3C%2Fpath%3E%3C%2Fg%3E%3Cg%20transform%3D%22rotate%2872%29%22%20transform-origin%3D%2212%2012%22%3E%3Cpath%20d%3D%22M%2021.510565162951536%208.909830056250526%20A%2010%2010%200%200%200%2012%206%22%20fill%3D%22none%22%20stroke%3D%22%23ff1744%22%20stroke-width%3D%224%22%3E%3C%2Fpath%3E%3C%2Fg%3E%3Cg%20transform%3D%22rotate%28144%29%22%20transform-origin%3D%2212%2012%22%3E%3Cpath%20d%3D%22M%2021.510565162951536%208.909830056250526%20A%2010%2010%200%200%200%2012%206%22%20fill%3D%22none%22%20stroke%3D%22%23d500f9%22%20stroke-width%3D%224%22%3E%3C%2Fpath%3E%3C%2Fg%3E%3Cg%20transform%3D%22rotate%28216%29%22%20transform-origin%3D%2212%2012%22%3E%3Cpath%20d%3D%22M%2021.510565162951536%208.909830056250526%20A%2010%2010%200%200%200%2012%206%22%20fill%3D%22none%22%20stroke%3D%22%23ffab00%22%20stroke-width%3D%224%22%3E%3C%2Fpath%3E%3C%2Fg%3E%3Cg%20transform%3D%22rotate%28288%29%22%20transform-origin%3D%2212%2012%22%3E%3Cpath%20d%3D%22M%2021.510565162951536%208.909830056250526%20A%2010%2010%200%200%200%2012%206%22%20fill%3D%22none%22%20stroke%3D%22%2300b0ff%22%20stroke-width%3D%224%22%3E%3C%2Fpath%3E%3C%2Fg%3E%3Cg%20transform%3D%22rotate%2872%29%22%20transform-origin%3D%2212%2012%22%3E%3Cpath%20d%3D%22M12.59%205.88Z%22%20fill%3D%22none%22%20stroke%3D%22%23aeea00%22%20stroke-width%3D%224.2%22%20stroke-linecap%3D%22round%22%3E%3C%2Fpath%3E%3C%2Fg%3E%3Cg%20transform%3D%22rotate%28144%29%22%20transform-origin%3D%2212%2012%22%3E%3Cpath%20d%3D%22M12.59%205.88Z%22%20fill%3D%22none%22%20stroke%3D%22%23ff1744%22%20stroke-width%3D%224.2%22%20stroke-linecap%3D%22round%22%3E%3C%2Fpath%3E%3C%2Fg%3E%3Cg%20transform%3D%22rotate%28216%29%22%20transform-origin%3D%2212%2012%22%3E%3Cpath%20d%3D%22M12.59%205.88Z%22%20fill%3D%22none%22%20stroke%3D%22%23d500f9%22%20stroke-width%3D%224.2%22%20stroke-linecap%3D%22round%22%3E%3C%2Fpath%3E%3C%2Fg%3E%3Cg%20transform%3D%22rotate%28288%29%22%20transform-origin%3D%2212%2012%22%3E%3Cpath%20d%3D%22M12.59%205.88Z%22%20fill%3D%22none%22%20stroke%3D%22%23ffab00%22%20stroke-width%3D%224.2%22%20stroke-linecap%3D%22round%22%3E%3C%2Fpath%3E%3C%2Fg%3E%3Cg%20transform%3D%22rotate%28360%29%22%20transform-origin%3D%2212%2012%22%3E%3Cpath%20d%3D%22M12.59%205.88Z%22%20fill%3D%22none%22%20stroke%3D%22%2300b0ff%22%20stroke-width%3D%224.2%22%20stroke-linecap%3D%22round%22%3E%3C%2Fpath%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E"
     />
-    <title>Paisa</title>
+    <title>Paisa+</title>
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">

--- a/src/lib/components/Navbar.svelte
+++ b/src/lib/components/Navbar.svelte
@@ -342,9 +342,9 @@
       {#if $obscure}
         <span class="icon is-small is-size-5">
           <i class="fas fa-user-secret"></i>
-        </span><span class="ml-2 is-primary-color">Paisa</span>
+        </span><span class="ml-2 is-primary-color">Paisa<sup>+</sup></span>
       {:else}
-        <Logo size={22} /><span class="ml-1 is-primary-color">Paisa</span>
+        <Logo size={22} /><span class="ml-1 is-primary-color">Paisa<sup>+</sup></span>
       {/if}
     </a>
 

--- a/src/routes/(app)/more/about/+page.svelte
+++ b/src/routes/(app)/more/about/+page.svelte
@@ -47,7 +47,7 @@
       <div class="column is-12">
         <div class="box has-text-centered px-3 mx-auto" style="max-width: 400px;">
           <div><Logo size={128} /></div>
-          <div class="is-size-3 is-primary-color">Paisa</div>
+          <div class="is-size-3 is-primary-color">Paisa<sup>+</sup></div>
           <div>
             Version: <b>{buildInfo.version}</b>
           </div>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -21,7 +21,7 @@
           <article class="message invertable is-danger">
             <div class="message-header">Something Went Wrong</div>
             <div class="message-body">
-              <p>Paisa has encountered a critical error</p>
+              <p>Paisa<sup>+</sup> has encountered a critical error</p>
               <p class="mt-2">{$page.error.message}</p>
               {#if $page.error.stack}
                 <pre class="mt-2">{$page.error.stack}</pre>

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -33,7 +33,9 @@
             <div class="flex justify-center items-center mb-2">
               <div class="mt-1 mr-1"><Logo size={32} /></div>
               <div class="is-size-3">
-                <a href="https://nextxm.github.io/paisa/" class="is-primary-color">Paisa</a>
+                <a href="https://nextxm.github.io/paisa/" class="is-primary-color"
+                  >Paisa<sup>+</sup></a
+                >
               </div>
             </div>
             <form

--- a/tests/fixture/eur-hledger/config.json
+++ b/tests/fixture/eur-hledger/config.json
@@ -91,7 +91,7 @@
     "$id": "https://nextxm.github.io/paisa/schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": false,
-    "description": "Paisa configuration",
+    "description": "Paisa+ configuration",
     "properties": {
       "accounts": {
         "default": [],
@@ -1588,7 +1588,7 @@
       "journal_path",
       "db_path"
     ],
-    "title": "Paisa",
+    "title": "Paisa+",
     "type": "object"
   }
 }

--- a/tests/fixture/eur/config.json
+++ b/tests/fixture/eur/config.json
@@ -91,7 +91,7 @@
     "$id": "https://nextxm.github.io/paisa/schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": false,
-    "description": "Paisa configuration",
+    "description": "Paisa+ configuration",
     "properties": {
       "accounts": {
         "default": [],
@@ -1588,7 +1588,7 @@
       "journal_path",
       "db_path"
     ],
-    "title": "Paisa",
+    "title": "Paisa+",
     "type": "object"
   }
 }

--- a/tests/fixture/inr-beancount/config.json
+++ b/tests/fixture/inr-beancount/config.json
@@ -99,8 +99,8 @@
   "schema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://nextxm.github.io/paisa/schema.json",
-    "title": "Paisa",
-    "description": "Paisa configuration",
+    "title": "Paisa+",
+    "description": "Paisa+ configuration",
     "type": "object",
     "properties": {
       "journal_path": {

--- a/tests/fixture/inr-hledger/config.json
+++ b/tests/fixture/inr-hledger/config.json
@@ -100,7 +100,7 @@
     "$id": "https://nextxm.github.io/paisa/schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": false,
-    "description": "Paisa configuration",
+    "description": "Paisa+ configuration",
     "properties": {
       "accounts": {
         "default": [],
@@ -1597,7 +1597,7 @@
       "journal_path",
       "db_path"
     ],
-    "title": "Paisa",
+    "title": "Paisa+",
     "type": "object"
   }
 }

--- a/tests/fixture/inr/config.json
+++ b/tests/fixture/inr/config.json
@@ -100,7 +100,7 @@
     "$id": "https://nextxm.github.io/paisa/schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": false,
-    "description": "Paisa configuration",
+    "description": "Paisa+ configuration",
     "properties": {
       "accounts": {
         "default": [],
@@ -1597,7 +1597,7 @@
       "journal_path",
       "db_path"
     ],
-    "title": "Paisa",
+    "title": "Paisa+",
     "type": "object"
   }
 }


### PR DESCRIPTION
This pull request updates the application's branding from "Paisa" to "Paisa+" across the desktop/web app, configuration schema, and test fixtures. It ensures that all user-facing strings, metadata, and configuration references consistently use the new "Paisa+" name.

Branding and Metadata Updates:

* Updated all UI references, metadata, and descriptions from "Paisa" to "Paisa+" in the main HTML template (`src/app.html`), navigation bar (`Navbar.svelte`), about page, login page, and error messages to reflect the new branding.
* Changed desktop app metadata, including `name`, `outputfilename`, `companyName`, and `productName` to "Paisa+" in `wails.json`.

Configuration Schema and Test Fixtures:

* Updated the configuration schema title and description from "Paisa" to "Paisa+" in `internal/config/schema.json`.
* Modified all test fixture config files to use "Paisa+" in the schema `title` and `description` fields for consistency. 

Documentation:

* Added a changelog entry summarizing the branding update and alignment of regression config fixtures with the new schema title/description.